### PR TITLE
Payload and result keys for highlighting hits in a corpus text

### DIFF
--- a/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
+++ b/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
@@ -1,7 +1,7 @@
 _id: spc_8ea7cfbb1b844196a75f9766a024be57
 type: ApiSpec
 parentId: wrk_6915256f54c24d51aa934588fd7b49ff
-modified: 1689856700832
+modified: 1689865361227
 created: 1675182326019
 fileName: Current Vicav API 1.0.0
 contents: "openapi: 3.1.0
@@ -3185,6 +3185,135 @@ contents: "openapi: 3.1.0
 
   \          content:
 
+  \            application/json:
+
+  \              schema:
+
+  \                $ref: '#/components/schemas/CorpusSearch'
+
+  \              examples:\ 
+
+  \                corpus_rearch_json:
+
+  \                  summary: 'Corpus serach results'
+
+  \                  value:\ 
+
+  \                    {
+
+  \                      \"query\":\"dār\",
+
+  \                      \"hits\":[
+
+  \                        {
+
+  \                          \"u\":\"URFA-077_a72\",
+
+  \                          \"doc\":\"URFA-077\",
+
+  \                          \"content\":\"<div
+  class=\\\"corpus-search-result\\\"
+  id=\\\"corpus-w-URFA-077_xTok_001078\\\"><div class=\\\"left\\\"><span
+  class=\\\"w\\\" id=\\\"URFA-077_xTok_001071\\\">āni<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-077_xTok_001072\\\">nāyim<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-077_xTok_001073\\\">hēne<\\/span><span xml:space=\\\"preserve\\\">
+  <\\/span><span class=\\\"w\\\" id=\\\"URFA-077_xTok_001074\\\">b<\\/span><span
+  class=\\\"w\\\" id=\\\"URFA-077_xTok_001076\\\">ad<\\/span><\\/div><div
+  class=\\\"keyword\\\"><span class=\\\"w\\\">dār<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><\\/div><div class=\\\"right\\\"><span
+  class=\\\"w\\\">haḏiyye<\\/span><span xml:space=\\\"preserve\\\">
+  <\\/span><span class=\\\"w\\\">nāyim<\\/span><span xml:space=\\\"preserve\\\">
+  <\\/span><\\/div><\\/div>\"
+
+  \                        },
+
+  \                        {
+
+  \                          \"u\":\"URFA-115_a4\",
+
+  \                          \"doc\":\"URFA-115\",
+
+  \                          \"content\":\"<div
+  class=\\\"corpus-search-result\\\"
+  id=\\\"corpus-w-URFA-115_xTok_000096\\\"><div class=\\\"left\\\"><span
+  class=\\\"w\\\" id=\\\"URFA-115_xTok_000087\\\">rəḥalaw<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-115_xTok_000089\\\">xall<\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-115_xTok_000091\\\">ō<\\/span><span xml:space=\\\"preserve\\\">
+  <\\/span><span class=\\\"w\\\" id=\\\"URFA-115_xTok_000092\\\">b<\\/span><span
+  class=\\\"w\\\" id=\\\"URFA-115_xTok_000094\\\">ad<\\/span><\\/div><div
+  class=\\\"keyword\\\"><span class=\\\"w\\\">dār<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><\\/div><div class=\\\"right\\\"><span
+  class=\\\"w\\\">w<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
+  class=\\\"w\\\">šālaw<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
+  class=\\\"w\\\">eger<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
+  class=\\\"w\\\">miṯil<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
+  class=\\\"w\\\">al<\\/span><\\/div><\\/div>\"
+
+  \                        },
+
+  \                        {
+
+  \                          \"u\":\"URFA-122_a13\",
+
+  \                          \"doc\":\"URFA-122\",
+
+  \                          \"content\":\"<div
+  class=\\\"corpus-search-result\\\"
+  id=\\\"corpus-w-URFA-122_xTok_000738\\\"><div class=\\\"left\\\"><span
+  class=\\\"w\\\" id=\\\"URFA-122_xTok_000730\\\">u<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-122_xTok_000731\\\">ˀal<\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-122_xTok_000733\\\">bāb<\\/span><span xml:space=\\\"preserve\\\">
+  <\\/span><span class=\\\"w\\\" id=\\\"URFA-122_xTok_000734\\\">b<\\/span><span
+  class=\\\"w\\\" id=\\\"URFA-122_xTok_000736\\\">ad<\\/span><\\/div><div
+  class=\\\"keyword\\\"><span class=\\\"w\\\">dār<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><\\/div><div class=\\\"right\\\"><span
+  class=\\\"w\\\">imčallṭīn<\\/span><span xml:space=\\\"preserve\\\">
+  <\\/span><span class=\\\"w\\\">al<\\/span><span
+  class=\\\"w\\\">qīrān<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
+  class=\\\"w\\\">aṭ<\\/span><span class=\\\"w\\\">ṭūg<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><\\/div><\\/div>\"
+
+  \                        },
+
+  \                        {
+
+  \                          \"u\":\"URFA-125_a9\",
+
+  \                          \"doc\":\"URFA-125\",
+
+  \                          \"content\":\"<div
+  class=\\\"corpus-search-result\\\"
+  id=\\\"corpus-w-URFA-125_xTok_000258\\\"><div class=\\\"left\\\"><span
+  class=\\\"w\\\" id=\\\"URFA-125_xTok_000253\\\">hēn<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-125_xTok_000254\\\">ṛāyiḥ<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-125_xTok_000255\\\">āni<\\/span><span xml:space=\\\"preserve\\\">
+  <\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-125_xTok_000256\\\">ˀarīd<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
+  id=\\\"URFA-125_xTok_000257\\\">agḏ̣ub<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><\\/div><div class=\\\"keyword\\\"><span
+  class=\\\"w\\\">dār<\\/span><span xml:space=\\\"preserve\\\">
+  <\\/span><\\/div><div class=\\\"right\\\"><span
+  class=\\\"w\\\">aš<\\/span><span class=\\\"w\\\">šēx<\\/span><span
+  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\">w<\\/span><span
+  class=\\\"w\\\">arīd<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
+  class=\\\"w\\\">āni<\\/span><span xml:space=\\\"preserve\\\">
+  <\\/span><\\/div><\\/div>\"
+
+  \                        }
+
+  \                      ]
+
+  \                    }
+
+  \         \ 
+
   \            application/xml:
 
   \              schema:
@@ -3889,6 +4018,44 @@ contents: "openapi: 3.1.0
   components:
 
   \  schemas:
+
+  \    CorpusSearch:
+
+  \      type: object
+
+  \      properties:\ 
+
+  \        query:\ 
+
+  \          type: string
+
+  \        hits:\ 
+
+  \          type: array
+
+  \          items:\ 
+
+  \            type:         \ 
+
+  \              $ref: '#/components/schemas/corpusSearch_hits'
+
+  \    corpusSearch_hits:\ 
+
+  \      type: object
+
+  \      properties:
+
+  \        u:\ 
+
+  \          type: string
+
+  \        doc:
+
+  \          type: string
+
+  \        content:\ 
+
+  \          type: string
 
   \    ProjectConfig:
 

--- a/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
+++ b/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
@@ -1,7 +1,7 @@
 _id: spc_8ea7cfbb1b844196a75f9766a024be57
 type: ApiSpec
 parentId: wrk_6915256f54c24d51aa934588fd7b49ff
-modified: 1689865361227
+modified: 1690027761242
 created: 1675182326019
 fileName: Current Vicav API 1.0.0
 contents: "openapi: 3.1.0
@@ -3193,7 +3193,7 @@ contents: "openapi: 3.1.0
 
   \              examples:\ 
 
-  \                corpus_rearch_json:
+  \                corpus_search_json:
 
   \                  summary: 'Corpus serach results'
 
@@ -3672,6 +3672,172 @@ contents: "openapi: 3.1.0
 
   \          content:
 
+  \            application/json:
+
+  \              schema:\ 
+
+  \                $ref: '#/components/schemas/CorpusText'
+
+  \              examples:\ 
+
+  \                corpustext_json:
+
+  \                  summary: sample json response
+
+  \                  value:
+
+  \                    {
+
+  \                      \"id\": \"$URFA-011\",
+
+  \                      \"utterances\": [
+
+  \                        {
+
+  \                          \"id\": \"URFA-011_a1\",
+
+  \                          \"content\": \"<div class=\\\"u\\\"
+  id=\\\"URFA-011_a1\\\" />\"
+
+  \                        },
+
+  \                        {
+
+  \                          \"id\": \"URFA-011_a2\",
+
+  \                          \"content\": \"<div class=\\\"u\\\"
+  id=\\\"URFA-011_a2\\\"><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000001\\\">hāḏa</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000002\\\">l</span><span>-</span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000004\\\">ᵊgbūr</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000005\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000006\\\">al</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000008\\\">miǧanne</span><span
+  class=\\\"pc\\\" id=\\\"xTok_000009\\\">,</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000010\\\">al</span><span>-</span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000012\\\">gabǝr</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000013\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000014\\\">wāḥad</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000015\\\">ymūt</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000016\\\">yidfunūn</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000018\\\">u</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000019\\\">hēne</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000020\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000021\\\">yidfunūn</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000023\\\">u</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000024\\\">yqasslūn</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000026\\\">u</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000027\\\">ʕala</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000028\\\">ʕurf</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000029\\\">islām</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000030\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000031\\\">ʕala</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000032\\\">ʕādāt</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000033\\\">uṣūl</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000034\\\">Islām</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000035\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000036\\\">yqassl</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000038\\\">u</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000039\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000040\\\">al</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000042\\\">xōǧe</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000043\\\">yqassl</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000045\\\">u</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000046\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000047\\\">w</span><span>-</span><span
+  class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000049\\\">yǧībūn</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000051\\\">u</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000052\\\">hēne</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000053\\\">yčaffnūn</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000055\\\">u</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000056\\\">yḥuṭṭūn</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000058\\\">u</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000059\\\">b</span><span>-</span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000061\\\">al</span><span>-</span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000063\\\">kefen</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000064\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000065\\\">čafan</span><span
+  class=\\\"pc\\\" id=\\\"xTok_000066\\\">–</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000067\\\">kefen</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000068\\\">–</span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000069\\\">čafan</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000070\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000071\\\">ydummūn</span><span>-</span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000073\\\">u</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000074\\\">.</span><span xml:space=\\\"preserve\\\">
+  </span></div>\"
+
+  \                        },
+
+  \                        {
+
+  \                          \"id\": \"URFA-011_a3\",
+
+  \                          \"content\": \"<div class=\\\"u\\\"
+  id=\\\"URFA-011_a3\\\"><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000075\\\">al</span><span>-</span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000077\\\">gabǝr</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000078\\\">baʕdēn</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000079\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000080\\\">ʕugub</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000081\\\">sabʕ</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000082\\\">ᵊsnīn</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000083\\\">yigdarūn</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000084\\\">yḥuṭṭūn</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000085\\\">qēr</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000086\\\">wāḥad</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000087\\\">bī</span><span>-</span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000089\\\">´</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000090\\\">.</span><span xml:space=\\\"preserve\\\"> </span><span
+  class=\\\"w\\\" id=\\\"URFA-011_xTok_000091\\\">in</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000092\\\">mā</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000093\\\">ṣār</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000094\\\">sabʕ</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000095\\\">ᵊsnīn</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000096\\\">qēr</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000097\\\">wāḥad</span><span
+  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000098\\\">mā</span><span xml:space=\\\"preserve\\\">
+  </span><span class=\\\"w\\\"
+  id=\\\"URFA-011_xTok_000099\\\">yḥuṭṭūn</span><span class=\\\"pc\\\"
+  id=\\\"xTok_000100\\\">.</span><span xml:space=\\\"preserve\\\">
+  </span></div>\"
+
+  \                        }
+
+  \                      ]
+
+  \                    }
+
   \            application/xml:
 
   \              schema:
@@ -4019,6 +4185,38 @@ contents: "openapi: 3.1.0
 
   \  schemas:
 
+  \    CorpusText:\ 
+
+  \      type: object
+
+  \      properties:\ 
+
+  \        id:\ 
+
+  \          type: string
+
+  \        utterances:
+
+  \          type: array
+
+  \          items:\ 
+
+  \            $ref: '#/components/schemas/corpusText_utterances'
+
+  \    corpusText_utterances:
+
+  \      type: object
+
+  \      properties:\ 
+
+  \        id:\ 
+
+  \          type: string
+
+  \        content:\ 
+
+  \          type: string
+
   \    CorpusSearch:
 
   \      type: object
@@ -4033,11 +4231,9 @@ contents: "openapi: 3.1.0
 
   \          type: array
 
-  \          items:\ 
+  \          items:         \ 
 
-  \            type:         \ 
-
-  \              $ref: '#/components/schemas/corpusSearch_hits'
+  \            $ref: '#/components/schemas/corpusSearch_hits'
 
   \    corpusSearch_hits:\ 
 

--- a/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
+++ b/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
@@ -1,7 +1,7 @@
 _id: spc_8ea7cfbb1b844196a75f9766a024be57
 type: ApiSpec
 parentId: wrk_6915256f54c24d51aa934588fd7b49ff
-modified: 1683286425412
+modified: 1683294553111
 created: 1675182326019
 fileName: Current Vicav API 1.0.0
 contents: >-
@@ -882,6 +882,48 @@ contents: >-
           '200':
             description: a list of geo markers
             content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    type: object
+                    schema:
+                      $ref: '#/components/schemas/Feature'
+                examples:
+                  geoJSON_features_Ma_geo_reg:
+                    summary: 'query: Ma.*. scope: geo_reg, shorted'
+                    value: [
+                            {
+                              "type": "Feature",
+                              "geometry": {
+                                "type": "Point",
+                                "coordinates": [
+                                  "35.578333",
+                                  "-5.368056"
+                                ]
+                              },
+                              "properties": {
+                                "type": "geo",
+                                "name": "Tétouan",
+                                "hitCount": "16"
+                              }
+                            },
+                            {
+                              "type": "Feature",
+                              "geometry": {
+                                "type": "Point",
+                                "coordinates": [
+                                  "32.000000",
+                                  "-6.000000"
+                                ]
+                              },
+                              "properties": {
+                                "type": "reg",
+                                "name": "Morocco",
+                                "hitCount": "1157"
+                              }
+                            }
+                          ]
               application/xml:
                 schema:
                   type: string
@@ -1500,4 +1542,49 @@ contents: >-
             $ref: '#/components/schemas/main_type'
           subnav:
             $ref: '#/components/schemas/subnav_type'
+      Feature:
+        title: GeoJSON Feature
+        type: object
+        required:
+        - type
+        - properties
+        - geometry
+        properties:
+          type:
+            type: string
+            enum:
+            - Feature
+          id:
+            oneOf:
+            - type: number
+            - type: string
+          properties:
+            oneOf:
+            - type: 'null'
+            - type: object
+          geometry:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/Point'    
+      Point:
+        title: GeoJSON Point
+        type: object
+        required:
+        - type
+        - coordinates
+        properties:
+          type:
+            type: string
+            enum:
+            - Point
+          coordinates:
+            type: array
+            minItems: 2
+            items:
+              type: number
+          bbox:
+            type: array
+            minItems: 4
+            items:
+              type: number
 contentType: yaml

--- a/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
+++ b/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
@@ -1,1590 +1,4222 @@
 _id: spc_8ea7cfbb1b844196a75f9766a024be57
 type: ApiSpec
 parentId: wrk_6915256f54c24d51aa934588fd7b49ff
-modified: 1683294553111
+modified: 1689856700832
 created: 1675182326019
 fileName: Current Vicav API 1.0.0
-contents: >-
-  openapi: 3.1.0
+contents: "openapi: 3.1.0
 
   jsonSchemaDialect: 'https://spec.openapis.org/oas/3.1/dialect/base'
 
   servers:
-    - url: https://vicav.acdh.oeaw.ac.at
-      description: "current ACDH-CH prod server"
-    - url: https://vicav.acdh-ch-dev.oeaw.ac.at/vicav
-      description: "current ACDH-CH dev server"
-    - url: https://vicav.acdh-ch-dev.oeaw.ac.at/vicav
-      description: "current ACDH-CH dev server"
-    # Added by API Auto Mocking Plugin
-    - description: SwaggerHub API Auto Mocking
-      url: https://virtserver.swaggerhub.com/ctot-nondef/Vicav/1.0.0
-    - url: http://localhost:8984/vicav
-      description: "local development"
+
+  \  - url: https://vicav.acdh.oeaw.ac.at
+
+  \    description: \"current ACDH-CH prod server\"
+
+  \  - url: https://vicav.acdh-ch-dev.oeaw.ac.at/vicav
+
+  \    description: \"current ACDH-CH dev server\"
+
+  \  - url: https://vicav.acdh-ch-dev.oeaw.ac.at/vicav
+
+  \    description: \"current ACDH-CH dev server\"
+
+  \  # Added by API Auto Mocking Plugin
+
+  \  - description: SwaggerHub API Auto Mocking
+
+  \    url: https://virtserver.swaggerhub.com/ctot-nondef/Vicav/1.0.0
+
+  \  - url: http://localhost:8984/vicav
+
+  \    description: \"local development\"
+
+  \  - url: http://shawi-local.acdh.oeaw.ac.at:8984/vicav
+
+  \    description: \"local development\"
+
   info:
-    description: This is the currently implemented vicav API
-    version: "1.0.0"
-    title: Current Vicav API
-    contact:
-      email: christoph.hoffmann@oeaw.ac.at
-    license:
-      name: MIT
-      url: 'https://opensource.org/licenses/MIT'
+
+  \  description: This is the currently implemented vicav API
+
+  \  version: \"1.0.0\"
+
+  \  title: Current Vicav API
+
+  \  contact:
+
+  \    email: christoph.hoffmann@oeaw.ac.at
+
+  \  license:
+
+  \    name: MIT
+
+  \    url: 'https://opensource.org/licenses/MIT'
+
   tags:
-    - name: noauth
-      description: Operations available without authentication
+
+  \  - name: noauth
+
+  \    description: Operations available without authentication
+
   paths:
-    /project:
-      get:
-        description: Get info about the project, menus and open panels/windows
-        tags:
-          - noauth
-        summary: gets basic project configuration
-        operationId: getProject
-        responses:
-          '200':
-            description: an xml with wrapped html contained
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/ProjectConfig'
-                examples:
-                  project_config_JSON:
-                    summary: the project configuration
-                    value: {
-                      "projectConfig": {
-                        "title": "VICAV3.0 - Vienna Corpus of Arabic Varieties",
-                        "logo": {
-                          "img": "images\/vicav_logo.svg"
-                        },
-                        "param": [
-                          ".*",
-                          "geo"
-                        ],
-                        "panel": [
-                          {
-                            "type": "text",
-                            "target": "li_vicavMission",
-                            "title": "MISSION"
-                          },
-                          {
-                            "type": "text",
-                            "target": "li_vicavNews",
-                            "title": "NEWS"
-                          }
-                        ],
-                        "menu": {
-                          "main": [
-                            {
-                              "id": "dropdown00",
-                              "title": "Project",
-                              "item": [
-                                {
-                                  "id": "li_vicavMission",
-                                  "title": "Mission",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavNews",
-                                  "title": "News",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "li_vicavTypesOfText",
-                                  "title": "Types of Text\/Data",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavContributors",
-                                  "title": "Contributors",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavLinguistics",
-                                  "title": "Linguistics",
-                                  "type": "item"
-                                }
-                              ],
-                              "type": "dropdown"
-                            },
-                            {
-                              "id": "dropdown01",
-                              "title": "Bibliographies",
-                              "item": [
-                                {
-                                  "id": "li_vicavExplanationBibliography",
-                                  "title": "Explanation",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "navBiblGeoMarkers",
-                                  "title": "All Bibl. Locations on Map",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "navBiblRegMarkers",
-                                  "title": "All Bibl. Regions on Map",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "navDictGeoRegMarkers",
-                                  "title": "All Dictionaries in Bibl. on Map",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "navTextbookGeoRegMarkers",
-                                  "title": "All Textbooks in Bibl. on Map",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "liBiblNewQuery",
-                                  "title": "Query Bibliography",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "li_vicavContributeBibliography",
-                                  "title": "Contribute to the Bibliography",
-                                  "type": "item"
-                                }
-                              ],
-                              "type": "dropdown"
-                            },
-                            {
-                              "id": "dropdown02",
-                              "title": "Profiles",
-                              "item": [
-                                {
-                                  "id": "li_vicavExplanationProfiles",
-                                  "title": "Explanation + List",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "navProfilesGeoRegMarkers",
-                                  "title": "Show All Profiles on Map",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "li_vicavContributeProfile",
-                                  "title": "Contribute a Profile",
-                                  "type": "item"
-                                }
-                              ],
-                              "type": "dropdown"
-                            },
-                            {
-                              "id": "dropdown03",
-                              "title": "Feature Lists",
-                              "item": [
-                                {
-                                  "id": "li_vicavExplanationFeatures",
-                                  "title": "Explanation",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "liVicavCrossFeatureQuery",
-                                  "title": "Cross-examine the VICAV Feature Lists",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "navFeaturesGeoRegMarkers",
-                                  "title": "Show All Feature Lists on Map",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "li_vicavContributeFeature",
-                                  "title": "Contribute a Feature List",
-                                  "type": "item"
-                                }
-                              ],
-                              "type": "dropdown"
-                            },
-                            {
-                              "id": "dropdown04",
-                              "title": "Samples",
-                              "item": [
-                                {
-                                  "id": "li_vicavExplanationSamples",
-                                  "title": "Explanation",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "navSamplesGeoRegMarkers",
-                                  "title": "Show All Samples on Map",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "liExploreSamples",
-                                  "title": "Compare Locations",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "li_vicavContributeSampleText",
-                                  "title": "Contribute a Sample Text",
-                                  "type": "item"
-                                }
-                              ],
-                              "type": "dropdown"
-                            },
-                            {
-                              "id": "dropdown05",
-                              "title": "Texts",
-                              "item": [
-                                {
-                                  "id": "li_vicavExplanationCorpusTexts",
-                                  "title": "Explanation and Overview",
-                                  "type": "item"
-                                }
-                              ],
-                              "type": "dropdown"
-                            },
-                            {
-                              "id": "dropdown06",
-                              "title": "Dictionaries",
-                              "item": [
-                                {
-                                  "id": "navDictGeoRegMarkers",
-                                  "title": "All Dictionaries in Bibl. on Map",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "navVicavDictMarkers",
-                                  "title": "All VICAV Dictionaries on Map",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "liVicavCrossDictQuery",
-                                  "title": "Query the VICAV Dictionaries",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "liVicavDict_Tunis",
-                                  "title": "TUNICO Dictionary",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "liVicavDict_Damascus",
-                                  "title": "Damascus Dictionary",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "liVicavDict_Cairo",
-                                  "title": "Cairo Dictionary",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "liVicavDict_Baghdad",
-                                  "title": "Baghdad Dictionary",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "liVicavDict_MSA",
-                                  "title": "MSA Dictionary",
-                                  "type": "item"
-                                },
-                                {
-                                  "type": "separator"
-                                },
-                                {
-                                  "id": "li_vicavDictionariesTechnicalities",
-                                  "title": "Technicalities",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavContributeDictionary",
-                                  "title": "Contribute a Dictionary\/Glossary",
-                                  "type": "item"
-                                }
-                              ],
-                              "type": "dropdown"
-                            },
-                            {
-                              "id": "dropdown07",
-                              "title": "Tools & Technology",
-                              "item": [
-                                {
-                                  "id": "li_vicavDictionaryEncoding",
-                                  "title": "Dictionary Encoding",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavVLE",
-                                  "title": "Dictionary Editor (VLE)",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavArabicTools",
-                                  "title": "Arabic Research Tools",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavOverview_corpora_spoken",
-                                  "title": "      Corpora (Spoken Varieties)",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavOverview_corpora_msa",
-                                  "title": "      Corpora (MSA)",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavOverview_special_corpora",
-                                  "title": "      Special Corpora",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavOverview_corpora_historical_varieties",
-                                  "title": "      Corpora (Historical Varieties)",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavOverview_dictionaries",
-                                  "title": "      Dictionaries",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavOverview_nlp",
-                                  "title": "      Language Processing Tools",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavOverview_otherStuff",
-                                  "title": "      Other Websites & Projects",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavLearning",
-                                  "title": "Learning Materials",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavLearning_tb_damascus",
-                                  "title": "      Textbook Syrian Arabic (Sound files)",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavLearningSmartphone",
-                                  "title": "      Vocabularies on Smartphones",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavLearningPrograms",
-                                  "title": "      Available Programs",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavLearningData",
-                                  "title": "      Available Data",
-                                  "type": "item"
-                                },
-                                {
-                                  "id": "li_vicavKeyboards",
-                                  "title": "Keyboard Layouts",
-                                  "type": "item"
-                                }
-                              ],
-                              "type": "dropdown"
-                            }
-                          ],
-                          "subnav": [
-                            {
-                              "id": "subNavBiblGeoMarkers",
-                              "class": "active",
-                              "title": "Bibl. Locations",
-                              "type": "item"
-                            },
-                            {
-                              "id": "subNavBiblRegMarkers",
-                              "title": "Bibl. Regions",
-                              "type": "item"
-                            },
-                            {
-                              "id": "subNavDictGeoRegMarkers",
-                              "title": "Bibl. (Dictionaries)",
-                              "type": "item"
-                            },
-                            {
-                              "id": "subNavTextbookGeoRegMarkers",
-                              "title": "Bibl. (Textbooks)",
-                              "type": "item"
-                            },
-                            {
-                              "id": "subNavProfilesGeoRegMarkers",
-                              "title": "Profiles",
-                              "type": "item"
-                            },
-                            {
-                              "id": "subNavFeaturesGeoRegMarkers",
-                              "title": "Features",
-                              "type": "item"
-                            },
-                            {
-                              "id": "subNavSamplesGeoRegMarkers",
-                              "title": "Samples",
-                              "type": "item"
-                            },
-                            {
-                              "id": "subNavVicavDictMarkers",
-                              "title": "VICAV Dictionaries",
-                              "type": "item"
-                            }
-                          ]
-                        }
-                      }
-                    }
-              application/xml:
-                schema:
-                  type: string
-                  xml:
-                    name: project
-                    wrapped: false
-                examples:
-                  project_config_XML_and_rendered_XHTML:
-                    summary: the project configuration
-                    value: >
-                      <project>
-                        <config>
-                          <projectConfig xml:space="preserve" id="vicav_config_vicav">
-                        <title>VICAV3.0 - Vienna Corpus of Arabic Varieties</title>
-                        <logo><img src="images/vicav_logo.svg"/></logo>
-                        <frontpage method="geo">
-                          <param>.*</param>
-                          <param>geo</param>
-                          <panel type="text" target="li_vicavMission">MISSION</panel>
-                          <panel type="text" target="li_vicavNews">NEWS</panel>
-                        </frontpage>
-                        <menu>
-                          <main>
-                            <dropdown xml:id="dropdown00" title="Project">
-                              <item xml:id="li_vicavMission">Mission</item>
-                              <item xml:id="li_vicavNews">News</item>
-                              <separator/>
-                              <item xml:id="li_vicavTypesOfText">Types of Text/Data</item>
-                              <item xml:id="li_vicavContributors">Contributors</item>
-                              <item xml:id="li_vicavLinguistics">Linguistics</item>
-                            </dropdown>
-                          </main>
-                          <subnav>
-                            <item xml:id="subNavBiblGeoMarkers" class="active">Bibl. Locations</item>
-                          </subnav>
-                        </menu>
-                      </projectConfig>
-                        </config>
-                        <renderedMenu>
-                          <menu xmlns="http://www.w3.org/1999/xhtml">
-                            <main>
-                              <ul class="navbar-nav mr-auto">
-                                <li class="nav-item dropdown">
-                                  <a class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdown00">Project</a>
-                                  <div class="dropdown-menu" aria-labelledby="dropdown00">
-                                    <a class="dropdown-item" id="li_vicavMission">Mission</a>
-                                    <a class="dropdown-item" id="li_vicavNews">News</a>
-                                    <div class="dropdown-divider"/>
-                                    <a class="dropdown-item" id="li_vicavTypesOfText">Types of Text/Data</a>
-                                    <a class="dropdown-item" id="li_vicavContributors">Contributors</a>
-                                    <a class="dropdown-item" id="li_vicavLinguistics">Linguistics</a>
-                                  </div>
-                                </li>
-                              </ul>
-                            </main>
-                            <subnav xmlns="">
-                              <span xmlns="http://www.w3.org/1999/xhtml" xml:space="preserve" id="subNavBiblGeoMarkers"><i class="fa fa-map" aria-hidden="true"/> Bibl. Locations</span>
-                            </subnav>
-                          </menu>
-                        </renderedMenu>
-                      </project>
-    /text:
-      get:
-        tags:
-          - noauth
-        summary: gets a description text identtified by its tei:div@xml:id
-        operationId: getText
-        description: |
-          By passing the appropriate xml-ID and xslt you can retrieve ready to display html
-        parameters:
-          - in: query
-            name: id
-            description: the @xml:id of the tei:div xml element
-            required: true
-            schema:
-              type: string
-          - in: query
-            name: xslt
-            required: false
-            description: the filename of the xslt transformation (for development purposes only)
-            schema:
-              type: string
-        responses:
-          '200':
-            description: the transformed html
-            content:
-              application/xml:
-                schema:
-                  type: string
-                  xml:
-                    name: div
-                    wrapped: false
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: >
-                      <div xmlns:tei="http://www.tei-c.org/ns/1.0">
 
-                      <table class="tbHeader">
-                      <tr>
-                      <td>
-                      <h2>Sample Texts (Explanation)</h2>
-                      </td>
-                      <td>{teiLink}</td>
-                      </tr>
-                      </table>
+  \  /project:
+
+  \    get:
+
+  \      description: Get info about the project, menus and open
+  panels/windows
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: gets basic project configuration
+
+  \      operationId: getProject
+
+  \      responses:
+
+  \        '200':
+
+  \          description: an xml with wrapped html contained
+
+  \          content:
+
+  \            application/json:
+
+  \              schema:
+
+  \                $ref: '#/components/schemas/ProjectConfig'
+
+  \              examples:
+
+  \                project_config_JSON:
+
+  \                  summary: the project configuration
+
+  \                  value: {
+
+  \                    \"projectConfig\": {
+
+  \                      \"title\": \"VICAV3.0 - Vienna Corpus of Arabic
+  Varieties\",
+
+  \                      \"logo\": {
+
+  \                        \"img\": \"images\\/vicav_logo.svg\"
+
+  \                      },
+
+  \                      \"param\": [
+
+  \                        \".*\",
+
+  \                        \"geo\"
+
+  \                      ],
+
+  \                      \"panel\": [
+
+  \                        {
+
+  \                          \"type\": \"text\",
+
+  \                          \"target\": \"li_vicavMission\",
+
+  \                          \"title\": \"MISSION\"
+
+  \                        },
+
+  \                        {
+
+  \                          \"type\": \"text\",
+
+  \                          \"target\": \"li_vicavNews\",
+
+  \                          \"title\": \"NEWS\"
+
+  \                        }
+
+  \                      ],
+
+  \                      \"menu\": {
+
+  \                        \"main\": [
+
+  \                          {
+
+  \                            \"id\": \"dropdown00\",
+
+  \                            \"title\": \"Project\",
+
+  \                            \"item\": [
+
+  \                              {
+
+  \                                \"id\": \"li_vicavMission\",
+
+  \                                \"title\": \"Mission\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavNews\",
+
+  \                                \"title\": \"News\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavTypesOfText\",
+
+  \                                \"title\": \"Types of Text\\/Data\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavContributors\",
+
+  \                                \"title\": \"Contributors\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavLinguistics\",
+
+  \                                \"title\": \"Linguistics\",
+
+  \                                \"type\": \"item\"
+
+  \                              }
+
+  \                            ],
+
+  \                            \"type\": \"dropdown\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"dropdown01\",
+
+  \                            \"title\": \"Bibliographies\",
+
+  \                            \"item\": [
+
+  \                              {
+
+  \                                \"id\":
+  \"li_vicavExplanationBibliography\",
+
+  \                                \"title\": \"Explanation\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"navBiblGeoMarkers\",
+
+  \                                \"title\": \"All Bibl. Locations on Map\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"navBiblRegMarkers\",
+
+  \                                \"title\": \"All Bibl. Regions on Map\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"navDictGeoRegMarkers\",
+
+  \                                \"title\": \"All Dictionaries in Bibl. on
+  Map\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"navTextbookGeoRegMarkers\",
+
+  \                                \"title\": \"All Textbooks in Bibl. on
+  Map\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"liBiblNewQuery\",
+
+  \                                \"title\": \"Query Bibliography\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavContributeBibliography\",
+
+  \                                \"title\": \"Contribute to the
+  Bibliography\",
+
+  \                                \"type\": \"item\"
+
+  \                              }
+
+  \                            ],
+
+  \                            \"type\": \"dropdown\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"dropdown02\",
+
+  \                            \"title\": \"Profiles\",
+
+  \                            \"item\": [
+
+  \                              {
+
+  \                                \"id\": \"li_vicavExplanationProfiles\",
+
+  \                                \"title\": \"Explanation + List\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"navProfilesGeoRegMarkers\",
+
+  \                                \"title\": \"Show All Profiles on Map\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavContributeProfile\",
+
+  \                                \"title\": \"Contribute a Profile\",
+
+  \                                \"type\": \"item\"
+
+  \                              }
+
+  \                            ],
+
+  \                            \"type\": \"dropdown\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"dropdown03\",
+
+  \                            \"title\": \"Feature Lists\",
+
+  \                            \"item\": [
+
+  \                              {
+
+  \                                \"id\": \"li_vicavExplanationFeatures\",
+
+  \                                \"title\": \"Explanation\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"liVicavCrossFeatureQuery\",
+
+  \                                \"title\": \"Cross-examine the VICAV
+  Feature Lists\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"navFeaturesGeoRegMarkers\",
+
+  \                                \"title\": \"Show All Feature Lists on
+  Map\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavContributeFeature\",
+
+  \                                \"title\": \"Contribute a Feature List\",
+
+  \                                \"type\": \"item\"
+
+  \                              }
+
+  \                            ],
+
+  \                            \"type\": \"dropdown\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"dropdown04\",
+
+  \                            \"title\": \"Samples\",
+
+  \                            \"item\": [
+
+  \                              {
+
+  \                                \"id\": \"li_vicavExplanationSamples\",
+
+  \                                \"title\": \"Explanation\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"navSamplesGeoRegMarkers\",
+
+  \                                \"title\": \"Show All Samples on Map\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"liExploreSamples\",
+
+  \                                \"title\": \"Compare Locations\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavContributeSampleText\",
+
+  \                                \"title\": \"Contribute a Sample Text\",
+
+  \                                \"type\": \"item\"
+
+  \                              }
+
+  \                            ],
+
+  \                            \"type\": \"dropdown\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"dropdown05\",
+
+  \                            \"title\": \"Texts\",
+
+  \                            \"item\": [
+
+  \                              {
+
+  \                                \"id\": \"li_vicavExplanationCorpusTexts\",
+
+  \                                \"title\": \"Explanation and Overview\",
+
+  \                                \"type\": \"item\"
+
+  \                              }
+
+  \                            ],
+
+  \                            \"type\": \"dropdown\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"dropdown06\",
+
+  \                            \"title\": \"Dictionaries\",
+
+  \                            \"item\": [
+
+  \                              {
+
+  \                                \"id\": \"navDictGeoRegMarkers\",
+
+  \                                \"title\": \"All Dictionaries in Bibl. on
+  Map\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"navVicavDictMarkers\",
+
+  \                                \"title\": \"All VICAV Dictionaries on
+  Map\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"liVicavCrossDictQuery\",
+
+  \                                \"title\": \"Query the VICAV
+  Dictionaries\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"liVicavDict_Tunis\",
+
+  \                                \"title\": \"TUNICO Dictionary\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"liVicavDict_Damascus\",
+
+  \                                \"title\": \"Damascus Dictionary\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"liVicavDict_Cairo\",
+
+  \                                \"title\": \"Cairo Dictionary\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"liVicavDict_Baghdad\",
+
+  \                                \"title\": \"Baghdad Dictionary\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"liVicavDict_MSA\",
+
+  \                                \"title\": \"MSA Dictionary\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"type\": \"separator\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\":
+  \"li_vicavDictionariesTechnicalities\",
+
+  \                                \"title\": \"Technicalities\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavContributeDictionary\",
+
+  \                                \"title\": \"Contribute a
+  Dictionary\\/Glossary\",
+
+  \                                \"type\": \"item\"
+
+  \                              }
+
+  \                            ],
+
+  \                            \"type\": \"dropdown\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"dropdown07\",
+
+  \                            \"title\": \"Tools & Technology\",
+
+  \                            \"item\": [
+
+  \                              {
+
+  \                                \"id\": \"li_vicavDictionaryEncoding\",
+
+  \                                \"title\": \"Dictionary Encoding\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavVLE\",
+
+  \                                \"title\": \"Dictionary Editor (VLE)\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavArabicTools\",
+
+  \                                \"title\": \"Arabic Research Tools\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\":
+  \"li_vicavOverview_corpora_spoken\",
+
+  \                                \"title\": \"      Corpora (Spoken
+  Varieties)\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavOverview_corpora_msa\",
+
+  \                                \"title\": \"      Corpora (MSA)\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\":
+  \"li_vicavOverview_special_corpora\",
+
+  \                                \"title\": \"      Special Corpora\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\":
+  \"li_vicavOverview_corpora_historical_varieties\",
+
+  \                                \"title\": \"      Corpora (Historical
+  Varieties)\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavOverview_dictionaries\",
+
+  \                                \"title\": \"      Dictionaries\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavOverview_nlp\",
+
+  \                                \"title\": \"      Language Processing
+  Tools\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavOverview_otherStuff\",
+
+  \                                \"title\": \"      Other Websites &
+  Projects\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavLearning\",
+
+  \                                \"title\": \"Learning Materials\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavLearning_tb_damascus\",
+
+  \                                \"title\": \"      Textbook Syrian Arabic
+  (Sound files)\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavLearningSmartphone\",
+
+  \                                \"title\": \"      Vocabularies on
+  Smartphones\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavLearningPrograms\",
+
+  \                                \"title\": \"      Available Programs\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavLearningData\",
+
+  \                                \"title\": \"      Available Data\",
+
+  \                                \"type\": \"item\"
+
+  \                              },
+
+  \                              {
+
+  \                                \"id\": \"li_vicavKeyboards\",
+
+  \                                \"title\": \"Keyboard Layouts\",
+
+  \                                \"type\": \"item\"
+
+  \                              }
+
+  \                            ],
+
+  \                            \"type\": \"dropdown\"
+
+  \                          }
+
+  \                        ],
+
+  \                        \"subnav\": [
+
+  \                          {
+
+  \                            \"id\": \"subNavBiblGeoMarkers\",
+
+  \                            \"class\": \"active\",
+
+  \                            \"title\": \"Bibl. Locations\",
+
+  \                            \"type\": \"item\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"subNavBiblRegMarkers\",
+
+  \                            \"title\": \"Bibl. Regions\",
+
+  \                            \"type\": \"item\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"subNavDictGeoRegMarkers\",
+
+  \                            \"title\": \"Bibl. (Dictionaries)\",
+
+  \                            \"type\": \"item\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"subNavTextbookGeoRegMarkers\",
+
+  \                            \"title\": \"Bibl. (Textbooks)\",
+
+  \                            \"type\": \"item\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"subNavProfilesGeoRegMarkers\",
+
+  \                            \"title\": \"Profiles\",
+
+  \                            \"type\": \"item\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"subNavFeaturesGeoRegMarkers\",
+
+  \                            \"title\": \"Features\",
+
+  \                            \"type\": \"item\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"subNavSamplesGeoRegMarkers\",
+
+  \                            \"title\": \"Samples\",
+
+  \                            \"type\": \"item\"
+
+  \                          },
+
+  \                          {
+
+  \                            \"id\": \"subNavVicavDictMarkers\",
+
+  \                            \"title\": \"VICAV Dictionaries\",
+
+  \                            \"type\": \"item\"
+
+  \                          }
+
+  \                        ]
+
+  \                      }
+
+  \                    }
+
+  \                  }
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: project
+
+  \                  wrapped: false
+
+  \              examples:
+
+  \                project_config_XML_and_rendered_XHTML:
+
+  \                  summary: the project configuration
+
+  \                  value: >
+
+  \                    <project>
+
+  \                      <config>
+
+  \                        <projectConfig xml:space=\"preserve\"
+  id=\"vicav_config_vicav\">
+
+  \                      <title>VICAV3.0 - Vienna Corpus of Arabic
+  Varieties</title>
+
+  \                      <logo><img src=\"images/vicav_logo.svg\"/></logo>
+
+  \                      <frontpage method=\"geo\">
+
+  \                        <param>.*</param>
+
+  \                        <param>geo</param>
+
+  \                        <panel type=\"text\"
+  target=\"li_vicavMission\">MISSION</panel>
+
+  \                        <panel type=\"text\"
+  target=\"li_vicavNews\">NEWS</panel>
+
+  \                      </frontpage>
+
+  \                      <menu>
+
+  \                        <main>
+
+  \                          <dropdown xml:id=\"dropdown00\"
+  title=\"Project\">
+
+  \                            <item xml:id=\"li_vicavMission\">Mission</item>
+
+  \                            <item xml:id=\"li_vicavNews\">News</item>
+
+  \                            <separator/>
+
+  \                            <item xml:id=\"li_vicavTypesOfText\">Types of
+  Text/Data</item>
+
+  \                            <item
+  xml:id=\"li_vicavContributors\">Contributors</item>
+
+  \                            <item
+  xml:id=\"li_vicavLinguistics\">Linguistics</item>
+
+  \                          </dropdown>
+
+  \                        </main>
+
+  \                        <subnav>
+
+  \                          <item xml:id=\"subNavBiblGeoMarkers\"
+  class=\"active\">Bibl. Locations</item>
+
+  \                        </subnav>
+
+  \                      </menu>
+
+  \                    </projectConfig>
+
+  \                      </config>
+
+  \                      <renderedMenu>
+
+  \                        <menu xmlns=\"http://www.w3.org/1999/xhtml\">
+
+  \                          <main>
+
+  \                            <ul class=\"navbar-nav mr-auto\">
+
+  \                              <li class=\"nav-item dropdown\">
+
+  \                                <a class=\"nav-link dropdown-toggle\"
+  data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"
+  id=\"dropdown00\">Project</a>
+
+  \                                <div class=\"dropdown-menu\"
+  aria-labelledby=\"dropdown00\">
+
+  \                                  <a class=\"dropdown-item\"
+  id=\"li_vicavMission\">Mission</a>
+
+  \                                  <a class=\"dropdown-item\"
+  id=\"li_vicavNews\">News</a>
+
+  \                                  <div class=\"dropdown-divider\"/>
+
+  \                                  <a class=\"dropdown-item\"
+  id=\"li_vicavTypesOfText\">Types of Text/Data</a>
+
+  \                                  <a class=\"dropdown-item\"
+  id=\"li_vicavContributors\">Contributors</a>
+
+  \                                  <a class=\"dropdown-item\"
+  id=\"li_vicavLinguistics\">Linguistics</a>
+
+  \                                </div>
+
+  \                              </li>
+
+  \                            </ul>
+
+  \                          </main>
+
+  \                          <subnav xmlns=\"\">
+
+  \                            <span xmlns=\"http://www.w3.org/1999/xhtml\"
+  xml:space=\"preserve\" id=\"subNavBiblGeoMarkers\"><i class=\"fa fa-map\"
+  aria-hidden=\"true\"/> Bibl. Locations</span>
+
+  \                          </subnav>
+
+  \                        </menu>
+
+  \                      </renderedMenu>
+
+  \                    </project>
+
+  \  /text:
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: gets a description text identtified by its tei:div@xml:id
+
+  \      operationId: getText
+
+  \      description: |
+
+  \        By passing the appropriate xml-ID and xslt you can retrieve ready
+  to display html
+
+  \      parameters:
+
+  \        - in: query
+
+  \          name: id
+
+  \          description: the @xml:id of the tei:div xml element
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: xslt
+
+  \          required: false
+
+  \          description: the filename of the xslt transformation (for
+  development purposes only)
+
+  \          schema:
+
+  \            type: string
+
+  \      responses:
+
+  \        '200':
+
+  \          description: the transformed html
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: div
+
+  \                  wrapped: false
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: >
+
+  \                    <div xmlns:tei=\"http://www.tei-c.org/ns/1.0\">
 
 
-                      <p>The sample texts are translations of the same
-                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:msa_sample_01/Modern Standard Arabic&#34;, this)">source text</a>. They vary slightly with respect to regional
-                      differences. However, they are homogeneous enough to allow students to
-                      compare the numerous linguistic phenomena displayed in the texts.</p>
+  \                    <table class=\"tbHeader\">
+
+  \                    <tr>
+
+  \                    <td>
+
+  \                    <h2>Sample Texts (Explanation)</h2>
+
+  \                    </td>
+
+  \                    <td>{teiLink}</td>
+
+  \                    </tr>
+
+  \                    </table>
 
 
-                      <p>Sofar we provide sample texts for six locations:
-                      <ul>
 
-                      <li>
-                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:baghdad_sample_01/Baghdad&#34;, this)">Baghdad</a>
-                      </li>
+  \                    <p>The sample texts are translations of the same
 
-                      <li>
-                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:cairo_sample_01/Cairo&#34;, this)">Cairo</a>
-                      </li>
+  \                    <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;sample:msa_sample_01/Modern Standard
+  Arabic&#34;, this)\">source text</a>. They vary slightly with respect to
+  regional
 
-                      <li>
-                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:damascus_sample_01/Damascus&#34;, this)">Damascus</a>
-                      </li>
+  \                    differences. However, they are homogeneous enough to
+  allow students to
 
-                      <li>
-                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:douz_sample_01/Douz&#34;, this)">Douz</a>
-                      </li>
+  \                    compare the numerous linguistic phenomena displayed in
+  the texts.</p>
 
-                      <li>
-                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:urfa_sample_01/%C5%9Eanl%C4%B1urfa&#34;, this)">Şanlıurfa</a>
-                      </li>
 
-                      <li>
-                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:tunis_sample_01/Tunis&#34;, this)">Tunis</a>
-                      </li>
-                      </ul>
-                      </p>
-                      </div>
-          '500':
-            description: bad input parameter
-            content:
-              application/xml:
-                schema:
-                  type: string
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
-    /profile:
-      get:
-        tags:
-          - noauth
-        summary: gets a langauge profile identified by its TEI@xml:id
-        operationId: getProfile
-        description: |
-          By passing the appropriate xml-ID and xslt you can retrieve ready to display html
-        parameters:
-          - in: query
-            name: id
-            description: the @xml:id of the TEI xml element
-            required: true
-            schema:
-              type: string
-          - in: query
-            name: coll
-            description: the id of the collection/database to use (for development purposes only)
-            required: false
-            schema:
-              type: string
-          - in: query
-            name: xslt
-            required: false
-            description: the filename of the xslt transformation (for development purposes only)
-            schema:
-              type: string
-        responses:
-          '200':
-            description: the transformed html
-            content:
-              application/xml:
-                schema:
-                  type: string
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: >
-                      <div xmlns="http://www.w3.org/1999/xhtml" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                      <table class="tbHeader">
-                      <tr>
-                      <td>
-                      <h2>Skoura</h2>
-                      </td>
-                      <td class="tdTeiLink">{teiLink}</td>
-                      </tr>
-                      </table>
-                      <div class="profileHeader">
-                      <div class="dvImgProfile"><img src="images/skoura_sp_2012.jpg"><div class="imgCaption">Courtesy of Stephan Procházka, 2012</div>
-                      </div>
-                      <table class="tbProfile">
-                      <tr>
-                      <td class="tdHead">MSA Name</td>
-                      <td class="tdProfileTableRight">سكورة</td>
-                      </tr>
-                      <tr>
-                      <td class="tdHead">MSA Name (trans.)</td>
-                      <td class="tdProfileTableRight">Sakūra Skūra</td>
-                      </tr>
-                      <tr>
-                      <td class="tdHead">Geo location</td>
-                      <td class="tdProfileTableRight"><i>
-                      31°03'N 06°33'W
-                      Morocco
-                      </i></td>
-                      </tr>
-                      <tr>
-                      <td class="tdHead">Contributed by</td>
-                      <td class="tdProfileTableRight"><i>Aleksandra Ercegovčević</i></td>
-                      </tr>
-                      </table>
-                      </div>
-                      <div class="h3ProfileTypology">Typology</div>
-                      <table class="tbProfile">
-                      <tr>
-                      <td colspan="2" class="tdProfileTableRight">West (Maghreb) › Morocco › Central type</td>
-                      </tr>
-                      <tr>
-                      <td colspan="2" class="tdProfileTableRight">Hilalian-type sedentary rural dialect with strong influence of Berber</td>
-                      </tr>
-                      </table>
-                      <div class="h3Profile">General</div>
 
-                      <div class="pNorm">Skūra is an Arabic enclave in the Berber-speaking area south of the High Atlas. Many
-                      of the 15,000 inhabitants are bilingual. They live mainly on agriculture and stock
-                      breeding.</div>
+  \                    <p>Sofar we provide sample texts for six locations:
 
-                      <div class="h3Profile">Research History</div>
+  \                    <ul>
 
-                      <div class="pNorm">All available data on the dialect of Skūra is from the work of Jorge Aguadé and Mohammad
-                      Elyaâcoubi. <a class="aVicText" href="javascript:getDBSnippet(&#34;zotid:8SISG2GK&#34;)">Aguadé 1994</a> is a brief study on the formation of the reflexive-passive forms of the verb. <a class="aVicText" href="javascript:getDBSnippet(&#34;zotid:E3T3HBCD&#34;)">Aguadé and Elyaacoubi 1995</a> is a monograph on the dialect with chapters on phonology, nominal and verbal morphology,
-                      and verb paradigms. <a class="aVicText" href="javascript:getDBSnippet(&#34;zotid:I3FIKENT&#34;)">Aguadé et al. 1996</a> deals with the irrigation system in the oasis of Skūra, and the technical terminology
-                      concerning irrigation in the dialect of Skūra. Elyaâcoubi 1998 treats the topic of
-                      the classification of south Moroccan Arabic dialects on the example of Skūra, where
-                      a three page-grammatical sketch of the dialect is also provided.</div>
 
-                      <div class="h3Profile">Dictionaries</div>
+  \                    <li>
 
-                      <div class="pNorm"><a class="aVicText" href="javascript:getDBSnippet(&#34;zotid:I3FIKENT&#34;)">Aguadé et al. 1996</a> includes a 2-page glossary of terminology related to the irrigation system (<i>xiṭṭāra</i>).</div>
+  \                    <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;sample:baghdad_sample_01/Baghdad&#34;,
+  this)\">Baghdad</a>
 
-                      <div class="h3Profile">Bibliography</div>
+  \                    </li>
 
-                      <div class="pNorm">To view publications on this variety click <a class="aVicText" href="javascript:getDBSnippet(&#34;bibl:geo:Skoura&#34;)">here</a>.</div>
-                      <br><br><br></div>
-          '500':
-            description: bad input parameter
-            content:
-              application/xml:
-                schema:
-                  type: string
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
-    /explore_samples:
-      get:
-        tags:
-          - noauth
-        summary: gets a specific html transformed via a specified xslt
-        operationId: getExploreSamples
-        description: |
-          By passing the appropriate xml-ID and xslt you can retrieve ready to display html
-        parameters:
-          - in: query
-            name: type
-            description: the type of query?
-            required: true
-            schema:
-              type: string
-          - in: query
-            name: word
-            description: the word to search for?
-            required: true
-            schema:
-              type: string
-          - in: query
-            name: xslt
-            required: false
-            description: the filename of the xslt transformation (for development purposes only)
-            schema:
-              type: string
-        responses:
-          '200':
-            description: the transformed html
-            content:
-              application/xml:
-                schema:
-                  type: string
-                  xml:
-                    name: div
-                    wrapped: false
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<div xmlns="http://www.w3.org/1999/xhtml" xmlns:tei="http://www.tei-c.org/ns/1.0"><div class="explore-samples"><table class="tbHeader"><tr><td><h2 xml:space="preserve">Compare samples</h2></td><td class="tdPrintLink"><a href="#" data-print="true" class="aTEIButton">Print</a></td></tr></table><div class="explore-samples-summary"><h4>Summary</h4><table><tr><th>unknown</th><td>1</td></tr></table></div><h3>3</h3><h4>unknown</h4><p xml:space="preserve">1 sentences found.</p><table class="tbFeatures"><tr><td class="tdFeaturesHeadRight"><small xml:space="preserve">%as</small></td><td class="tdFeaturesRightTarget"><a class="show-sentence" title="Show full sample text" href="#" data-sampletext="douz_sample_01"><i class="fa fa-eye" aria-hidden="true"><span/></i></a><span xmlns:acdh="http://acdh.oeaw.ac.at" class="spSentence" xml:space="preserve"><span class="sample-text-tooltip" data-html="true" data-toggle="tooltip" data-placement="top" title="Tomaten nahm ich keine, weil sie sehr teuer&#xA;                     waren."><i class="fa fa-commenting-o" aria-hidden="true"><span/></i></span> <a class="word-search" href="#" data-wordform="mā" data-type="sample"><span data-html="true" data-placement="top" class="w">mā</span></a><a class="word-search" href="#" data-wordform="-" data-type="sample"><span data-html="true" data-placement="top" class="w">-</span></a><a class="word-search" href="#" data-wordform="šrīt" data-type="sample"><span data-html="true" data-placement="top" class="w highlight">šrīt</span></a><a class="word-search" href="#" data-wordform="-" data-type="sample"><span data-html="true" data-placement="top" class="w">-</span></a><a class="word-search" href="#" data-wordform="ǝš" data-type="sample"><span data-html="true" data-placement="top" class="w">ǝš</span></a> <a class="word-search" href="#" data-wordform="iṭ" data-type="sample"><span data-html="true" data-placement="top" class="w">iṭ</span></a><a class="word-search" href="#" data-wordform="-" data-type="sample"><span data-html="true" data-placement="top" class="w">-</span></a><a class="word-search" href="#" data-wordform="ṭamāṭim" data-type="sample"><span data-html="true" data-placement="top" class="w">ṭamāṭim</span></a> <a class="word-search" href="#" data-wordform="ʿal" data-type="sample"><span data-html="true" data-placement="top" class="w">ʿal</span></a><a class="word-search" href="#" data-wordform="-" data-type="sample"><span data-html="true" data-placement="top" class="w">-</span></a><a class="word-search" href="#" data-wordform="xāṭir" data-type="sample"><span data-html="true" data-placement="top" class="w">xāṭir</span></a> <a class="word-search" href="#" data-wordform="kānat" data-type="sample"><span data-html="true" data-placement="top" class="w">kānat</span></a> <a class="word-search" href="#" data-wordform="ġālya" data-type="sample"><span data-html="true" data-placement="top" class="w">ġālya</span></a><a class="word-search" href="#" data-wordform="." data-type="sample"><span data-html="true" data-placement="top" class="w">.</span></a> </span></td></tr></table></div></div>'
-          '500':
-            description: bad input parameter
-            content:
-              application/xml:
-                schema:
-                  type: string
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
-    /biblio_tei:
-      get:
-        tags:
-          - noauth
-        summary: gets a specific html transformed via a specified xslt
-        operationId: getBiblioTei
-        description: |
-          By passing a well formed query and xslt you can retrieve ready to display html
-        parameters:
-          - in: query
-            name: query
-            description: the query
-            required: true
-            schema:
-              type: string
-          - in: query
-            name: xslt
-            required: false
-            description: the filename of the xslt transformation (for development purposes only)
-            schema:
-              type: string
-        responses:
-          '200':
-            description: the transformed html
-            content:
-              application/xml:
-                schema:
-                  type: string
-                  xml:
-                    name: div
-                    wrapped: false
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<div xmlns:tei="http://www.tei-c.org/ns/1.0"><div class="dvStats">Query:  <span class="spQueryText">{query}</span></div><div class="dvStats">1 record </div><div class="dvBibBook"><div class="dvAuthor"><b>Hagenbucher,<span xml:space="preserve"> </span>F.</b></div><div class="dvBiblBlock"><img class="imgBiblItem" src="images/book_001.jpg"/>Les arabes dits “suwa” du Nord-Cameroun.<span xml:space="preserve"> </span>Yaounde.<span xml:space="preserve"> </span>ORSTOM.<span xml:space="preserve"> </span>1973.</div></div></div>'
-          '500':
-            description: bad input parameter
-            content:
-              application/xml:
-                schema:
-                  type: string
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
-    /bibl_markers_tei:
-      get:
-        tags:
-          - noauth
-        summary: gets a geo marker information 
-        operationId: getMarkers
-        description: |
-          Retrieve geo data information from the bibliography for displaying coordinates on a map.
-        parameters:
-          - in: query
-            name: query
-            description: |
-              A BaseX Full-Text search query in in vicav-biblio tei:biblstruct with wildcards enabled.
-              See: https://docs.basex.org/wiki/Full-Text#Match_Options
-              using wildcards using diacritics sensitive
-              Uses prefixes to limit the full text search to certein elements.
-              * date: -> tei:date
-              * title: -> tei:title
-              * pubPlace: -> tei:pubPlace
-              * author: -> tei:author/tei:surname
-              * geo:, geo_reg:, reg:, diaGroup: -> tei:note[@type="tag"]/tei:name
-              * vt:, prj: -> tei:note[@type="tag"]
-              
-              Without a prefix any text in vicav-biblio tei:biblstruct is searched.
-              
-              More than one query is possible by separating with ' '/+.
-            required: true
-            schema:
-              type: string
-          - in: query
-            name: scope
-            required: true
-            description: |
-              Filters based on a set of tei:name/@types being present in a tei:note[tei:geo]           
-              * geo
-              * diaGroup
-              * reg
-              * geo_reg: any of the above
-            schema:
-              type: string            
-              enum:
-              - geo_reg
-              - geo
-              - reg
-              - diaGroup
-        responses:
-          '200':
-            description: a list of geo markers
-            content:
-              application/json:
-                schema:
-                  type: array
-                  items:
-                    type: object
-                    schema:
-                      $ref: '#/components/schemas/Feature'
-                examples:
-                  geoJSON_features_Ma_geo_reg:
-                    summary: 'query: Ma.*. scope: geo_reg, shorted'
-                    value: [
-                            {
-                              "type": "Feature",
-                              "geometry": {
-                                "type": "Point",
-                                "coordinates": [
-                                  "35.578333",
-                                  "-5.368056"
-                                ]
-                              },
-                              "properties": {
-                                "type": "geo",
-                                "name": "Tétouan",
-                                "hitCount": "16"
-                              }
-                            },
-                            {
-                              "type": "Feature",
-                              "geometry": {
-                                "type": "Point",
-                                "coordinates": [
-                                  "32.000000",
-                                  "-6.000000"
-                                ]
-                              },
-                              "properties": {
-                                "type": "reg",
-                                "name": "Morocco",
-                                "hitCount": "1157"
-                              }
-                            }
-                          ]
-              application/xml:
-                schema:
-                  type: string
-                  xml:
-                    name: rs
-                    wrapped: false
-                  items:
-                    type: object
-                examples:
-                  xml:
-                    summary: a list of geo markers
-                    value: >
-                      <rs type="60">
-                        <r type="geo">
-                          <geo>35.578333 -5.368056</geo>
-                          <alt>Tétouan</alt>
-                          <freq>1</freq>
-                        </r>
-                        <r type="reg">
-                          <geo>32.000000 -6.000000</geo>
-                          <alt>Morocco</alt>
-                          <freq>44</freq>
-                        </r>
-                        <r type="reg">
-                          <geo>34.000000 9.000000</geo>
-                          <alt>Tunisia</alt>
-                          <freq>4</freq>
-                        </r>
-                      </rs>
-          '500':
-            description: bad input parameter
-            content:
-              application/xml:
-                schema:
-                  type: string
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
-    /{name}_markers:
-      get:
-        tags:
-          - noauth
-        summary: gets a specific xml
-        operationId: sampleMarkers
-        description: |
-          I have no idea
-        parameters:
-          - in: path
-            name: name
-            description: a reference to a predefined query?
-            required: true
-            schema:
-              type: string
-        responses:
-          '200':
-            description: an xml result list
-            content:
-              application/xml:
-                schema:
-                  type: string
-                  xml:
-                    name: rs
-                    wrapped: false
-                  items:
-                    type: object
-                examples:
-                  xml:
-                    summary: A list of geo markers
-                    value: >
-                      <rs>
-                        <r type="geo" xml:id="baghdad_sample_01">
-                          <loc>33°20'N 44°24'E</loc>
-                          <locName>
-                            <name xmlns="http://www.tei-c.org/ns/1.0" xml:lang="eng">Baghdad</name>
-                          </locName>
-                          <alt>
-                            <name xmlns="http://www.tei-c.org/ns/1.0" xml:lang="eng">Baghdad</name>
-                          </alt>
-                          <freq>1</freq>
-                        </r>
-                        <r type="geo" xml:id="cairo_sample_01">
-                          <loc>30°03'N 31°14'E</loc>
-                          <locName>
-                            <name xmlns="http://www.tei-c.org/ns/1.0" xml:lang="eng">Cairo</name>
-                          </locName>
-                          <alt>
-                            <name xmlns="http://www.tei-c.org/ns/1.0" xml:lang="eng">Cairo</name>
-                          </alt>
-                          <freq>1</freq>
-                        </r>
-                      </rs>
-          '404':
-            description: not found
-            content:
-              application/xml:
-                schema:
-                  type: string
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
-    /dict_api:
-      get:
-        tags:
-          - noauth
-        summary: gets a specific html transformed via a specified xslt
-        operationId: getDictApi
-        description: |
-          By passing a well formed query and xslt you can retrieve ready to display html
-        parameters:
-          - in: query
-            name: query
-            description: the query
-            required: true
-            schema:
-              type: string
-          - in: query
-            name: dict
-            description: the dict id?
-            required: true
-            schema:
-              type: string
-          - in: query
-            name: xslt
-            required: false
-            description: the filename of the xslt transformation (for development purposes only)
-            schema:
-              type: string
-        responses:
-          '200':
-            description: the transformed html
-            content:
-              application/xml:
-                schema:
-                  type: string
-                  xml:
-                    name: div
-                    wrapped: false
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: >
-                      <div xmlns="http://www.w3.org/1999/xhtml" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                      <div class="dvStats" id="dvStats">0&nbsp;hits</div>
-                      </div>
-          '500':
-            description: bad input parameter
-            content:
-              application/xml:
-                schema:
-                  type: string
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
-    /dict_index:
-      get:
-        tags:
-          - noauth
-        summary: gets a specific html transformed via a specified xslt
-        operationId: getDictIndex
-        description: |
-          By passing a well formed query you can retrieve ready to display html
-        parameters:
-          - in: query
-            name: dict
-            description: the dict id?
-            required: true
-            schema:
-              type: string
-          - in: query
-            name: ind
-            required: true
-            description: I have no idea
-            schema:
-              type: string
-              enum:
-                - any
-                - lem
-                - infl
-                - en
-                - de
-                - fr
-                - pos
-                - root
-                - subc
-                - etymSrc
-                - etymLang
-          - in: query
-            name: str
-            required: true
-            description: the query string?
-            schema:
-              type: string
-        responses:
-          '200':
-            description: the transformed html
-            content:
-              application/xml:
-                schema:
-                  type: string
-                  xml:
-                    name: div
-                    wrapped: false
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: >
-                      <div xmlns="http://www.w3.org/1999/xhtml">
-                      <option class="opWordList_de">'[abstauben]</option>
-                      <option class="opWordList_de">[Abbilden]</option>
-                      <option class="opWordList_de">[Abdruck]</option>
-                      <option class="opWordList_de">[Abend]</option>
-                      <option class="opWordList_de">[Abend]-</option>
-                      <option class="opWordList_de">[Abendessen]</option>
-                      <option class="opWordList_de">[Abendgebet]</option>
-                      <option class="opWordList_de">[Abenteuer]</option>
-                      <option class="opWordList_de">[Abfall]</option>
-                      <option class="opWordList_de">[Abfallhaufen]</option>
-                      <option class="opWordList_de">[Abflussloch]</option>
-                      <option class="opWordList_de">[Abflussrinne]</option>
-                      <option class="opWordList_de">[Abflussrohr]</option>
-                      <option class="opWordList_de">[Abflußkanal]</option>
-                      <option class="opWordList_de">[Abgeordnetenhaus]</option>
-                      <option class="opWordList_de">[Abgeordnetenkammer]</option>
-                      <option class="opWordList_de">[Abgeordneter]</option>
-                      <option class="opWordList_de">[Abgeschiedenheit]</option>
-                      <option class="opWordList_de">[Abitur]</option>
-                      <option class="opWordList_de">[Abkürzung]</option>
-                      <option class="opWordList_de">[Ablenkung]</option>
-                      <option class="opWordList_de">[Ablflussrinne]</option>
-                      <option class="opWordList_de">[Ablutionskännchen]</option>
-                      <option class="opWordList_de">[Abmachung]</option>
-                      <option class="opWordList_de">[Abort]</option>
-                      <option class="opWordList_de">[Abortgrube]</option>
-                      <option class="opWordList_de">[Absatz]</option>
-                      <option class="opWordList_de">[Abscheu]</option>
-                      <option class="opWordList_de">[Abscheulichkeit]</option>
-                      <option class="opWordList_de">[Abschiedsgruß]</option>
-                      <option class="opWordList_de">[Abschneiden]</option>
-                      <option class="opWordList_de">[Abschnitt]</option>
-                      <option class="opWordList_de">[Absender]</option>
-                      <option class="opWordList_de">[Absicht]</option>
-                      <option class="opWordList_de">[Abstand]</option>
-                      <option class="opWordList_de">[Abstellbrett]</option>
-                      <option class="opWordList_de">[Abstellraum]</option>
-                      <option class="opWordList_de">[Abstieg]</option>
-                      <option class="opWordList_de">[Abszess]</option>
-                      <option class="opWordList_de">[Abteilungsleiter]</option>
-                      <option class="opWordList_de">[Abtritt]</option>
-                      <option class="opWordList_de">[Abwesenheit]</option>
-                      <option class="opWordList_de">[Abwickeln]</option>
-                      <option class="opWordList_de">[Abzweigung]</option>
-                      <option class="opWordList_de">[abbiegen]</option>
-                      <option class="opWordList_de">[abbrechen]</option>
-                      <option class="opWordList_de">[abdecken]</option>
-                      <option class="opWordList_de">[abendlich]</option>
-                      <option class="opWordList_de">[abendländisch]</option>
-                      <option class="opWordList_de">[aber]</option>
-                      <option class="opWordList_de">[abfahren]</option>
-                      <option class="opWordList_de">[abfangen]</option>
-                      <option class="opWordList_de">[abgeben]</option>
-                      <option class="opWordList_de">[abgebildet]</option>
-                      <option class="opWordList_de">[abgenutzt]</option>
-                      <option class="opWordList_de">[abgeschrieben]</option>
-                      <option class="opWordList_de">[abgeschält]</option>
-                      <option class="opWordList_de">[abgestempelt]</option>
-                      <option class="opWordList_de">[abgewirtschaftet]</option>
-                      <option class="opWordList_de">[abhauen]</option>
-                      <option class="opWordList_de">[abheben]</option>
-                      <option class="opWordList_de">[abhäuten]</option>
-                      <option class="opWordList_de">[ablehnen]</option>
-                      <option class="opWordList_de">[abliefern]</option>
-                      <option class="opWordList_de">[abmagern]</option>
-                      <option class="opWordList_de">[abnehmen]</option>
-                      <option class="opWordList_de">[abnormal]</option>
-                      <option class="opWordList_de">[abreisen]</option>
-                      <option class="opWordList_de">[abreißen]</option>
-                      <option class="opWordList_de">[abschaben]</option>
-                      <option class="opWordList_de">[abscheulich]</option>
-                      <option class="opWordList_de">[abschlachten]</option>
-                      <option class="opWordList_de">[abschneiden]</option>
-                      <option class="opWordList_de">[abschreiben]</option>
-                      <option class="opWordList_de">[abseihen]</option>
-                      <option class="opWordList_de">[absengen]</option>
-                      <option class="opWordList_de">[absichtlich]</option>
-                      <option class="opWordList_de">[absteigen]</option>
-                      <option class="opWordList_de">[abstoßen]</option>
-                      <option class="opWordList_de">[abstreiten]</option>
-                      <option class="opWordList_de">[abwaschen]</option>
-                      <option class="opWordList_de">[abwesend]</option>
-                      <option class="opWordList_de">[abwischen]</option>
-                      <option class="opWordList_de">[abziehen]</option>
-                      <option class="opWordList_en">[abdomen]</option>
-                      <option class="opWordList_en">[abhorrence]</option>
-                      <option class="opWordList_en">[ability]</option>
-                      <option class="opWordList_en">[ablution]</option>
-                      <option class="opWordList_en">[about]</option>
-                      <option class="opWordList_en">[above]</option>
-                      <option class="opWordList_en">[abroad]</option>
-                      <option class="opWordList_en">[abscess]</option>
-                      <option class="opWordList_en">[absence]</option>
-                      <option class="opWordList_en">[absent]</option>
-                      <option class="opWordList_en">[absolutely]</option>
-                      <option class="opWordList_en">[abundantly]</option>
-                      <option class="opWordList_fr">[abaissement]</option>
-                      <option class="opWordList_fr">[abaisser]</option>
-                      <option class="opWordList_fr">[abattage]</option>
-                      <option class="opWordList_fr">[abattement]</option>
-                      <option class="opWordList_fr">[abattre]</option>
-                      <option class="opWordList_fr">[abattu]</option>
-                      <option class="opWordList_fr">[abdomen]</option>
-                      <option class="opWordList_fr">[abeilles]</option>
-                      <option class="opWordList_fr">[ablution]</option>
-                      <option class="opWordList_fr">[aboiement]</option>
-                      <option class="opWordList_fr">[abonder]</option>
-                      <option class="opWordList_fr">[aboyer]</option>
-                      <option class="opWordList_fr">[abreuver]</option>
-                      <option class="opWordList_fr">[abricots]</option>
-                      <option class="opWordList_fr">[absence]</option>
-                      <option class="opWordList_fr">[absent]</option>
-                      <option class="opWordList_fr">[absolument]</option>
-                      <option class="opWordList_fr">[absolutment]</option>
-                      <option class="opWordList_fr">[abuser]</option>
-                      <option class="opWordList_fr">[abîmé]</option>
-                      <option class="opWordList_de">([Ab])hang</option>
-                      <option class="opWordList_de">([Ab])wiegen</option>
-                      <option class="opWordList_de">(Geld) [abheben]</option>
-                      <option class="opWordList_de">(Staub) [abklopfen]</option>
-                      <option class="opWordList_de">(Unter-)[Abteilung]</option>
-                      <option class="opWordList_de">(Zigarette) [abaschen]</option>
-                      <option class="opWordList_de">([ab])stützen</option>
-                      <option class="opWordList_de">([ab])wägen</option>
-                      <option class="opWordList_de">([ab]-)lecken</option>
-                      <option class="opWordList_de">(edle) [Abstammung]</option>
-                      <option class="opWordList_de">(früher) [Abend]</option>
-                      <option class="opWordList_de">(gute) [Absicht]</option>
-                      <option class="opWordList_de">(stark) [abnehmen]</option>
-                      <option class="opWordList_de">[Abscheu] erregen</option>
-                      <option class="opWordList_de">[Abschied] nehmen</option>
-                      <option class="opWordList_de">Guten [Abend]!</option>
-                      <option class="opWordList_de">Hau [ab]!</option>
-                      <option class="opWordList_de">Luft [ablassen]</option>
-                      <option class="opWordList_de">Stimme [abgeben]</option>
-                      <option class="opWordList_de">[abendliche] Feier</option>
-                      <option class="opWordList_de">[aber]...nicht</option>
-                      <option class="opWordList_de">[abgehen] (Zug)</option>
-                      <option class="opWordList_de">[abgenützt] werden</option>
-                      <option class="opWordList_de">[abgerissenes] Kleidungsstück</option>
-                      <option class="opWordList_de">[abgeschnittene] Locke</option>
-                      <option class="opWordList_de">[abgesehen] davon</option>
-                      <option class="opWordList_de">[abgesehen] von</option>
-                      <option class="opWordList_de">[abheben] (Geld)</option>
-                      <option class="opWordList_de">[abhängen] von</option>
-                      <option class="opWordList_de">[abhängig] von</option>
-                      <option class="opWordList_de">[abhören] (Patient)</option>
-                      <option class="opWordList_de">[ablassen] von</option>
-                      <option class="opWordList_de">[abschleppen] (Auto)</option>
-                      <option class="opWordList_de">[abspülen] (Geschirr)</option>
-                      <option class="opWordList_de">[abstürzen] (Computer</option>
-                      <option class="opWordList_de">[abtrünniger] Muslim</option>
-                      <option class="opWordList_de">[abwesend] sein</option>
-                      <option class="opWordList_de">[abzielen] auf</option>
-                      <option class="opWordList_de">en [abondance]</option>
-                      <option class="opWordList_de">etw. [abbrechen]</option>
-                      <option class="opWordList_de">etw. [abkratzen]</option>
-                      <option class="opWordList_de">gegen [Abend]</option>
-                      <option class="opWordList_de">heute [Abend]</option>
-                      <option class="opWordList_de">langsam [abfließen]</option>
-                      <option class="opWordList_de">mit [Absicht]</option>
-                      <option class="opWordList_de">nun [aber]</option>
-                      <option class="opWordList_de">sich [abmühen]</option>
-                      <option class="opWordList_de">vorgestern [Abend]</option>
-                      <option class="opWordList_en">[about] what</option>
-                      <option class="opWordList_en">[absolutely] nothing</option>
-                      <option class="opWordList_en">caring [about]</option>
-                      <option class="opWordList_en">from [above]</option>
-                      <option class="opWordList_en">from [abroad]</option>
-                      <option class="opWordList_en">to [abandon]</option>
-                      <option class="opWordList_en">to [abound]</option>
-                      <option class="opWordList_en">to [abuse]</option>
-                      <option class="opWordList_fr">[aborder] qc.</option>
-                      <option class="opWordList_fr">[abîmer] qc.</option>
-                      <option class="opWordList_fr">d'[abord]</option>
-                      <option class="opWordList_fr">devenir [abondant]</option>
-                      <option class="opWordList_fr">d’[abord]</option>
-                      <option class="opWordList_fr">règle [absolue]</option>
-                      <option class="opWordList_fr">s’[abîmer]</option>
-                      <option class="opWordList_fr">être [abandonné]</option>
-                      <option class="opWordList_fr">être [absent]</option>
-                      <option class="opWordList_de">([ab])wiegen (Gewicht)</option>
-                      <option class="opWordList_de">(die Schule/ das Studium) [abschließen]/[absolvieren]</option>
-                      <option class="opWordList_de">[Ablegen] von Gegenständen</option>
-                      <option class="opWordList_de">[Abreibung] (mit Seife)</option>
-                      <option class="opWordList_de">[Abweichung] (vom Rechten)</option>
-                      <option class="opWordList_de">[abgerissenes] zerlumptes Kleidungsstück</option>
-                      <option class="opWordList_de">[abgewickelt] werden (Geschäft)</option>
-                      <option class="opWordList_de">[abhängig] sein von</option>
-                      <option class="opWordList_de">[abnehmen] (den Telefonhörer)</option>
-                      <option class="opWordList_de">an jenem [Abend]</option>
-                      <option class="opWordList_de">austreten (auf [Abort])</option>
-                      <option class="opWordList_de">das Fell [abziehen]</option>
-                      <option class="opWordList_de">die [Absicht] habend...</option>
-                      <option class="opWordList_de">eine [Abteilung] Soldaten</option>
-                      <option class="opWordList_de">mit der [Absicht]</option>
-                      <option class="opWordList_de">sich (gegenseitig) [abküssen]</option>
-                      <option class="opWordList_de">sich [abwenden] von</option>
-                      <option class="opWordList_de">sich [abzeichnend] (Konturen)</option>
-                      <option class="opWordList_de">von ihm [abfallen]</option>
-                      <option class="opWordList_de">zu [Abend] essen</option>
-                      <option class="opWordList_de">zu [Abend] speisen</option>
-                      <option class="opWordList_en">hanging [about]/around</option>
-                      <option class="opWordList_en">to [abandon] sth.</option>
-                      <option class="opWordList_en">to [abate] (price)</option>
-                      <option class="opWordList_en">to be [abandoned]</option>
-                      <option class="opWordList_en">to be [able]</option>
-                      <option class="opWordList_en">to be [absent]</option>
-                      <option class="opWordList_en">to complain [about]</option>
-                      <option class="opWordList_en">to laze ([about])</option>
-                      <option class="opWordList_en">to reflect ([about])</option>
-                      <option class="opWordList_en">to strut [about]</option>
-                      <option class="opWordList_en">to think ([about])</option>
-                      <option class="opWordList_en">to worry [about]</option>
-                      <option class="opWordList_en">wandering [about]/around</option>
-                      <option class="opWordList_fr">[abandonner] qn./qc.</option>
-                      <option class="opWordList_fr">[abri] de fortune</option>
-                      <option class="opWordList_fr">ne... [absolument] personne</option>
-                      <option class="opWordList_fr">s'[abattre] sur</option>
-                      <option class="opWordList_fr">s’[absenter] (de)</option>
-                      <option class="opWordList_fr">tout d'[abord]</option>
-                      <option class="opWordList_de">[Absatz]/Stöckel der Schuhe</option>
-                      <option class="opWordList_de">[Abzug] (e-r Feuerwaffe)</option>
-                      <option class="opWordList_de">[Abzugsloch] unter der Feuerstelle</option>
-                      <option class="opWordList_de">[abgeschnittene] Locke der Braut</option>
-                      <option class="opWordList_de">[abgewinkelter] Eingangsbereich tunesischer Häuser</option>
-                      <option class="opWordList_de">[abschätziger] und verächtlicher Mann</option>
-                      <option class="opWordList_de">[abschüssige](r) Straße/ Weg</option>
-                      <option class="opWordList_de">des [Ablegens] von Kleidung</option>
-                      <option class="opWordList_de">die den Kachelfries [abschließt]</option>
-                      <option class="opWordList_de">eine große Schau [abziehen]</option>
-                      <option class="opWordList_de">j-m etw. [abknöpfen]</option>
-                      <option class="opWordList_de">j-m etw. [abluchsen]</option>
-                      <option class="opWordList_de">mit j-m [abrechnen]</option>
-                      <option class="opWordList_en">it is [absolutely] necessary</option>
-                      <option class="opWordList_en">to be passionate [about]</option>
-                      <option class="opWordList_en">to become [abundant]/plentiful</option>
-                      <option class="opWordList_en">to hang [about]/around</option>
-                      <option class="opWordList_en">to philosophize [about] sth.</option>
-                      <option class="opWordList_en">to wander [about]/around</option>
-                      <option class="opWordList_fr">avoir l'esprit [absent]</option>
-                      <option class="opWordList_fr">chevelure [abondante] et indisciplinée</option>
-                      <option class="opWordList_fr">il est [absolument] necessaire</option>
-                      <option class="opWordList_de">Schuheisen (für Spitze und [Absatz])</option>
-                      <option class="opWordList_de">Unterleder von Sohle und [Absatz]</option>
-                      <option class="opWordList_de">Wasch- und Wasserstelle sowie [Abort]</option>
-                      <option class="opWordList_de">[aber] geduldete) Zuschauerin (bei Familienfeiern)</option>
-                      <option class="opWordList_de">[abmessen] (mit e-m Hohlmaß</option>
-                      <option class="opWordList_de">an den Festtagen Verwandtschaftsbesuche [absolviert])</option>
-                      <option class="opWordList_de">befreien (verstopften Gang/Kanal/[Abfluss]</option>
-                      <option class="opWordList_de">der die einheimischen Märkte [abmacht]</option>
-                      <option class="opWordList_de">die das Trauerjahr [abschließende] Zeremonie</option>
-                      <option class="opWordList_de">mittels e-s Schlosses [ab]-</option>
-                      <option class="opWordList_en">to acquire knowledge [about] sth.</option>
-                      <option class="opWordList_en">to gossip [about] sb./sth.</option>
-                      <option class="opWordList_en">to perform the ritual [ablution]</option>
-                      <option class="opWordList_en">to talk [about] sth./sb.</option>
-                      <option class="opWordList_de">Feier zur schriftlichen [Abfassung] eines Heiratsübereinkommens</option>
-                      <option class="opWordList_de">Student bzw. [Absolvent] der Zitouna-Hochschule</option>
-                      <option class="opWordList_de">bei einer Prüfung schummeln oder [abschreiben]</option>
-                      <option class="opWordList_de">den Kuskusdämpfer mittels der qfīla [abdichten]</option>
-                      <option class="opWordList_de">sich [absichern] (durch Rücklagen o. ä.)</option>
-                      <option class="opWordList_en">to doubt of/[about] sth./sb.</option>
-                      <option class="opWordList_fr">employer [abondamment] le mot pénis (zibb)</option>
-                      <option class="opWordList_de">die als [Abgrenzung] einer landwirtschaftlichen Fläche dienen</option>
-                      <option class="opWordList_de">die gerne [abends] ausgeht und gerne feiert</option>
-                      <option class="opWordList_de">eifersüchtig auf die [Abgeschlossenheit] seiner Frau Bedachter</option>
-                      <option class="opWordList_en">a unit of mass ([about] 5 g)</option>
-                      <option class="opWordList_en">to [abundantly] use the word penis (zibb)</option>
-                      <option class="opWordList_en">to say bad things [about] sb./sth.</option>
-                      <option class="opWordList_de">[aber] von Männern wie Frauen unter sich gebraucht)</option>
-                      <option class="opWordList_de">die Verbindung/den Kontakt zu j-m [abbrechen]</option>
-                      <option class="opWordList_de">bezüglich auf einen Studenten bzw. [Absolventen] der Zitouna-Hochschule</option>
-                      <option class="opWordList_de">das Fell von Schlachttieren (an Schädel und Läufen) [absengen]</option>
-                      <option class="opWordList_en">What do I/do you/does he etc. think ([about]...)?</option>
-                      <option class="opWordList_de">sehr feine und geschmeidige Pantoffel mit [abgerundeter] Spitze und aus Kamelleder</option>
-                      <option class="opWordList_de">und 9. Tag nach einem Todesfall der leidtragenden Familie [abstattete] (obsoleter Brauch)</option>
-                      </div>
-          '500':
-            description: bad input parameter
-            content:
-              application/xml:
-                schema:
-                  type: string
-                examples:
-                  html:
-                    summary: A sample HTML response
-                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+
+  \                    <li>
+
+  \                    <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;sample:cairo_sample_01/Cairo&#34;,
+  this)\">Cairo</a>
+
+  \                    </li>
+
+
+  \                    <li>
+
+  \                    <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;sample:damascus_sample_01/Damascus&#34;,
+  this)\">Damascus</a>
+
+  \                    </li>
+
+
+  \                    <li>
+
+  \                    <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;sample:douz_sample_01/Douz&#34;,
+  this)\">Douz</a>
+
+  \                    </li>
+
+
+  \                    <li>
+
+  \                    <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;sample:urfa_sample_01/%C5%9Eanl%C4%B1urfa\
+  &#34;, this)\">Şanlıurfa</a>
+
+  \                    </li>
+
+
+  \                    <li>
+
+  \                    <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;sample:tunis_sample_01/Tunis&#34;,
+  this)\">Tunis</a>
+
+  \                    </li>
+
+  \                    </ul>
+
+  \                    </p>
+
+  \                    </div>
+
+  \        '500':
+
+  \          description: bad input parameter
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
+
+  \  /profile:
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: gets a langauge profile identified by its TEI@xml:id
+
+  \      operationId: getProfile
+
+  \      description: |
+
+  \        By passing the appropriate xml-ID and xslt you can retrieve ready
+  to display html
+
+  \      parameters:
+
+  \        - in: query
+
+  \          name: id
+
+  \          description: the @xml:id of the TEI xml element
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: coll
+
+  \          description: the id of the collection/database to use (for
+  development purposes only)
+
+  \          required: false
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: xslt
+
+  \          required: false
+
+  \          description: the filename of the xslt transformation (for
+  development purposes only)
+
+  \          schema:
+
+  \            type: string
+
+  \      responses:
+
+  \        '200':
+
+  \          description: the transformed html
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: >
+
+  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\"
+  xmlns:tei=\"http://www.tei-c.org/ns/1.0\">
+
+  \                    <table class=\"tbHeader\">
+
+  \                    <tr>
+
+  \                    <td>
+
+  \                    <h2>Skoura</h2>
+
+  \                    </td>
+
+  \                    <td class=\"tdTeiLink\">{teiLink}</td>
+
+  \                    </tr>
+
+  \                    </table>
+
+  \                    <div class=\"profileHeader\">
+
+  \                    <div class=\"dvImgProfile\"><img
+  src=\"images/skoura_sp_2012.jpg\"><div class=\"imgCaption\">Courtesy of
+  Stephan Procházka, 2012</div>
+
+  \                    </div>
+
+  \                    <table class=\"tbProfile\">
+
+  \                    <tr>
+
+  \                    <td class=\"tdHead\">MSA Name</td>
+
+  \                    <td class=\"tdProfileTableRight\">سكورة</td>
+
+  \                    </tr>
+
+  \                    <tr>
+
+  \                    <td class=\"tdHead\">MSA Name (trans.)</td>
+
+  \                    <td class=\"tdProfileTableRight\">Sakūra Skūra</td>
+
+  \                    </tr>
+
+  \                    <tr>
+
+  \                    <td class=\"tdHead\">Geo location</td>
+
+  \                    <td class=\"tdProfileTableRight\"><i>
+
+  \                    31°03'N 06°33'W
+
+  \                    Morocco
+
+  \                    </i></td>
+
+  \                    </tr>
+
+  \                    <tr>
+
+  \                    <td class=\"tdHead\">Contributed by</td>
+
+  \                    <td class=\"tdProfileTableRight\"><i>Aleksandra
+  Ercegovčević</i></td>
+
+  \                    </tr>
+
+  \                    </table>
+
+  \                    </div>
+
+  \                    <div class=\"h3ProfileTypology\">Typology</div>
+
+  \                    <table class=\"tbProfile\">
+
+  \                    <tr>
+
+  \                    <td colspan=\"2\" class=\"tdProfileTableRight\">West
+  (Maghreb) › Morocco › Central type</td>
+
+  \                    </tr>
+
+  \                    <tr>
+
+  \                    <td colspan=\"2\"
+  class=\"tdProfileTableRight\">Hilalian-type sedentary rural dialect with
+  strong influence of Berber</td>
+
+  \                    </tr>
+
+  \                    </table>
+
+  \                    <div class=\"h3Profile\">General</div>
+
+
+  \                    <div class=\"pNorm\">Skūra is an Arabic enclave in the
+  Berber-speaking area south of the High Atlas. Many
+
+  \                    of the 15,000 inhabitants are bilingual. They live
+  mainly on agriculture and stock
+
+  \                    breeding.</div>
+
+
+  \                    <div class=\"h3Profile\">Research History</div>
+
+
+  \                    <div class=\"pNorm\">All available data on the dialect
+  of Skūra is from the work of Jorge Aguadé and Mohammad
+
+  \                    Elyaâcoubi. <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;zotid:8SISG2GK&#34;)\">Aguadé 1994</a> is
+  a brief study on the formation of the reflexive-passive forms of the verb. <a
+  class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;zotid:E3T3HBCD&#34;)\">Aguadé and
+  Elyaacoubi 1995</a> is a monograph on the dialect with chapters on phonology,
+  nominal and verbal morphology,
+
+  \                    and verb paradigms. <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;zotid:I3FIKENT&#34;)\">Aguadé et al.
+  1996</a> deals with the irrigation system in the oasis of Skūra, and the
+  technical terminology
+
+  \                    concerning irrigation in the dialect of Skūra.
+  Elyaâcoubi 1998 treats the topic of
+
+  \                    the classification of south Moroccan Arabic dialects on
+  the example of Skūra, where
+
+  \                    a three page-grammatical sketch of the dialect is also
+  provided.</div>
+
+
+  \                    <div class=\"h3Profile\">Dictionaries</div>
+
+
+  \                    <div class=\"pNorm\"><a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;zotid:I3FIKENT&#34;)\">Aguadé et al.
+  1996</a> includes a 2-page glossary of terminology related to the irrigation
+  system (<i>xiṭṭāra</i>).</div>
+
+
+  \                    <div class=\"h3Profile\">Bibliography</div>
+
+
+  \                    <div class=\"pNorm\">To view publications on this
+  variety click <a class=\"aVicText\"
+  href=\"javascript:getDBSnippet(&#34;bibl:geo:Skoura&#34;)\">here</a>.</div>
+
+  \                    <br><br><br></div>
+
+  \        '500':
+
+  \          description: bad input parameter
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
+
+  \  /explore_samples:
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: gets a specific html transformed via a specified xslt
+
+  \      operationId: getExploreSamples
+
+  \      description: |
+
+  \        By passing the appropriate xml-ID and xslt you can retrieve ready
+  to display html
+
+  \      parameters:
+
+  \        - in: query
+
+  \          name: type
+
+  \          description: the type of query?
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: word
+
+  \          description: the word to search for?
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: xslt
+
+  \          required: false
+
+  \          description: the filename of the xslt transformation (for
+  development purposes only)
+
+  \          schema:
+
+  \            type: string
+
+  \      responses:
+
+  \        '200':
+
+  \          description: the transformed html
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: div
+
+  \                  wrapped: false
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<div xmlns=\"http://www.w3.org/1999/xhtml\"
+  xmlns:tei=\"http://www.tei-c.org/ns/1.0\"><div
+  class=\"explore-samples\"><table class=\"tbHeader\"><tr><td><h2
+  xml:space=\"preserve\">Compare samples</h2></td><td class=\"tdPrintLink\"><a
+  href=\"#\" data-print=\"true\"
+  class=\"aTEIButton\">Print</a></td></tr></table><div
+  class=\"explore-samples-summary\"><h4>Summary</h4><table><tr><th>unknown</th>\
+  <td>1</td></tr></table></div><h3>3</h3><h4>unknown</h4><p
+  xml:space=\"preserve\">1 sentences found.</p><table
+  class=\"tbFeatures\"><tr><td class=\"tdFeaturesHeadRight\"><small
+  xml:space=\"preserve\">%as</small></td><td class=\"tdFeaturesRightTarget\"><a
+  class=\"show-sentence\" title=\"Show full sample text\" href=\"#\"
+  data-sampletext=\"douz_sample_01\"><i class=\"fa fa-eye\"
+  aria-hidden=\"true\"><span/></i></a><span
+  xmlns:acdh=\"http://acdh.oeaw.ac.at\" class=\"spSentence\"
+  xml:space=\"preserve\"><span class=\"sample-text-tooltip\" data-html=\"true\"
+  data-toggle=\"tooltip\" data-placement=\"top\" title=\"Tomaten nahm ich keine,
+  weil sie sehr teuer&#xA;                     waren.\"><i class=\"fa
+  fa-commenting-o\" aria-hidden=\"true\"><span/></i></span> <a
+  class=\"word-search\" href=\"#\" data-wordform=\"mā\"
+  data-type=\"sample\"><span data-html=\"true\" data-placement=\"top\"
+  class=\"w\">mā</span></a><a class=\"word-search\" href=\"#\"
+  data-wordform=\"-\" data-type=\"sample\"><span data-html=\"true\"
+  data-placement=\"top\" class=\"w\">-</span></a><a class=\"word-search\"
+  href=\"#\" data-wordform=\"šrīt\" data-type=\"sample\"><span
+  data-html=\"true\" data-placement=\"top\" class=\"w
+  highlight\">šrīt</span></a><a class=\"word-search\" href=\"#\"
+  data-wordform=\"-\" data-type=\"sample\"><span data-html=\"true\"
+  data-placement=\"top\" class=\"w\">-</span></a><a class=\"word-search\"
+  href=\"#\" data-wordform=\"ǝš\" data-type=\"sample\"><span data-html=\"true\"
+  data-placement=\"top\" class=\"w\">ǝš</span></a> <a class=\"word-search\"
+  href=\"#\" data-wordform=\"iṭ\" data-type=\"sample\"><span data-html=\"true\"
+  data-placement=\"top\" class=\"w\">iṭ</span></a><a class=\"word-search\"
+  href=\"#\" data-wordform=\"-\" data-type=\"sample\"><span data-html=\"true\"
+  data-placement=\"top\" class=\"w\">-</span></a><a class=\"word-search\"
+  href=\"#\" data-wordform=\"ṭamāṭim\" data-type=\"sample\"><span
+  data-html=\"true\" data-placement=\"top\" class=\"w\">ṭamāṭim</span></a> <a
+  class=\"word-search\" href=\"#\" data-wordform=\"ʿal\"
+  data-type=\"sample\"><span data-html=\"true\" data-placement=\"top\"
+  class=\"w\">ʿal</span></a><a class=\"word-search\" href=\"#\"
+  data-wordform=\"-\" data-type=\"sample\"><span data-html=\"true\"
+  data-placement=\"top\" class=\"w\">-</span></a><a class=\"word-search\"
+  href=\"#\" data-wordform=\"xāṭir\" data-type=\"sample\"><span
+  data-html=\"true\" data-placement=\"top\" class=\"w\">xāṭir</span></a> <a
+  class=\"word-search\" href=\"#\" data-wordform=\"kānat\"
+  data-type=\"sample\"><span data-html=\"true\" data-placement=\"top\"
+  class=\"w\">kānat</span></a> <a class=\"word-search\" href=\"#\"
+  data-wordform=\"ġālya\" data-type=\"sample\"><span data-html=\"true\"
+  data-placement=\"top\" class=\"w\">ġālya</span></a><a class=\"word-search\"
+  href=\"#\" data-wordform=\".\" data-type=\"sample\"><span data-html=\"true\"
+  data-placement=\"top\" class=\"w\">.</span></a>
+  </span></td></tr></table></div></div>'
+
+  \        '500':
+
+  \          description: bad input parameter
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
+
+  \  /biblio_tei:
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: gets a specific html transformed via a specified xslt
+
+  \      operationId: getBiblioTei
+
+  \      description: |
+
+  \        By passing a well formed query and xslt you can retrieve ready to
+  display html
+
+  \      parameters:
+
+  \        - in: query
+
+  \          name: query
+
+  \          description: the query
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: xslt
+
+  \          required: false
+
+  \          description: the filename of the xslt transformation (for
+  development purposes only)
+
+  \          schema:
+
+  \            type: string
+
+  \      responses:
+
+  \        '200':
+
+  \          description: the transformed html
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: div
+
+  \                  wrapped: false
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<div
+  xmlns:tei=\"http://www.tei-c.org/ns/1.0\"><div class=\"dvStats\">Query:  <span
+  class=\"spQueryText\">{query}</span></div><div class=\"dvStats\">1
+  record </div><div class=\"dvBibBook\"><div
+  class=\"dvAuthor\"><b>Hagenbucher,<span xml:space=\"preserve\">
+  </span>F.</b></div><div class=\"dvBiblBlock\"><img class=\"imgBiblItem\"
+  src=\"images/book_001.jpg\"/>Les arabes dits “suwa” du Nord-Cameroun.<span
+  xml:space=\"preserve\"> </span>Yaounde.<span xml:space=\"preserve\">
+  </span>ORSTOM.<span xml:space=\"preserve\"> </span>1973.</div></div></div>'
+
+  \        '500':
+
+  \          description: bad input parameter
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
+
+  \  /bibl_markers_tei:
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: gets a geo marker information\ 
+
+  \      operationId: getMarkers
+
+  \      description: |
+
+  \        Retrieve geo data information from the bibliography for displaying
+  coordinates on a map.
+
+  \      parameters:
+
+  \        - in: query
+
+  \          name: query
+
+  \          description: |
+
+  \            A BaseX Full-Text search query in in vicav-biblio
+  tei:biblstruct with wildcards enabled.
+
+  \            See: https://docs.basex.org/wiki/Full-Text#Match_Options
+
+  \            using wildcards using diacritics sensitive
+
+  \            Uses prefixes to limit the full text search to certein
+  elements.
+
+  \            * date: -> tei:date
+
+  \            * title: -> tei:title
+
+  \            * pubPlace: -> tei:pubPlace
+
+  \            * author: -> tei:author/tei:surname
+
+  \            * geo:, geo_reg:, reg:, diaGroup: ->
+  tei:note[@type=\"tag\"]/tei:name
+
+  \            * vt:, prj: -> tei:note[@type=\"tag\"]
+
+  \           \ 
+
+  \            Without a prefix any text in vicav-biblio tei:biblstruct is
+  searched.
+
+  \           \ 
+
+  \            More than one query is possible by separating with ' '/+.
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: scope
+
+  \          required: true
+
+  \          description: |
+
+  \            Filters based on a set of tei:name/@types being present in a
+  tei:note[tei:geo]          \ 
+
+  \            * geo
+
+  \            * diaGroup
+
+  \            * reg
+
+  \            * geo_reg: any of the above
+
+  \          schema:
+
+  \            type: string           \ 
+
+  \            enum:
+
+  \            - geo_reg
+
+  \            - geo
+
+  \            - reg
+
+  \            - diaGroup
+
+  \      responses:
+
+  \        '200':
+
+  \          description: a list of geo markers
+
+  \          content:
+
+  \            application/json:
+
+  \              schema:
+
+  \                type: array
+
+  \                items:
+
+  \                  type: object
+
+  \                  schema:
+
+  \                    $ref: '#/components/schemas/Feature'
+
+  \              examples:
+
+  \                geoJSON_features_Ma_geo_reg:
+
+  \                  summary: 'query: Ma.*. scope: geo_reg, shorted'
+
+  \                  value: [
+
+  \                          {
+
+  \                            \"type\": \"Feature\",
+
+  \                            \"geometry\": {
+
+  \                              \"type\": \"Point\",
+
+  \                              \"coordinates\": [
+
+  \                                \"35.578333\",
+
+  \                                \"-5.368056\"
+
+  \                              ]
+
+  \                            },
+
+  \                            \"properties\": {
+
+  \                              \"type\": \"geo\",
+
+  \                              \"name\": \"Tétouan\",
+
+  \                              \"hitCount\": \"16\"
+
+  \                            }
+
+  \                          },
+
+  \                          {
+
+  \                            \"type\": \"Feature\",
+
+  \                            \"geometry\": {
+
+  \                              \"type\": \"Point\",
+
+  \                              \"coordinates\": [
+
+  \                                \"32.000000\",
+
+  \                                \"-6.000000\"
+
+  \                              ]
+
+  \                            },
+
+  \                            \"properties\": {
+
+  \                              \"type\": \"reg\",
+
+  \                              \"name\": \"Morocco\",
+
+  \                              \"hitCount\": \"1157\"
+
+  \                            }
+
+  \                          }
+
+  \                        ]
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: rs
+
+  \                  wrapped: false
+
+  \                items:
+
+  \                  type: object
+
+  \              examples:
+
+  \                xml:
+
+  \                  summary: a list of geo markers
+
+  \                  value: >
+
+  \                    <rs type=\"60\">
+
+  \                      <r type=\"geo\">
+
+  \                        <geo>35.578333 -5.368056</geo>
+
+  \                        <alt>Tétouan</alt>
+
+  \                        <freq>1</freq>
+
+  \                      </r>
+
+  \                      <r type=\"reg\">
+
+  \                        <geo>32.000000 -6.000000</geo>
+
+  \                        <alt>Morocco</alt>
+
+  \                        <freq>44</freq>
+
+  \                      </r>
+
+  \                      <r type=\"reg\">
+
+  \                        <geo>34.000000 9.000000</geo>
+
+  \                        <alt>Tunisia</alt>
+
+  \                        <freq>4</freq>
+
+  \                      </r>
+
+  \                    </rs>
+
+  \        '500':
+
+  \          description: bad input parameter
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
+
+  \  /{name}_markers:
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: gets a specific xml
+
+  \      operationId: sampleMarkers
+
+  \      description: |
+
+  \        I have no idea
+
+  \      parameters:
+
+  \        - in: path
+
+  \          name: name
+
+  \          description: a reference to a predefined query?
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \      responses:
+
+  \        '200':
+
+  \          description: an xml result list
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: rs
+
+  \                  wrapped: false
+
+  \                items:
+
+  \                  type: object
+
+  \              examples:
+
+  \                xml:
+
+  \                  summary: A list of geo markers
+
+  \                  value: >
+
+  \                    <rs>
+
+  \                      <r type=\"geo\" xml:id=\"baghdad_sample_01\">
+
+  \                        <loc>33°20'N 44°24'E</loc>
+
+  \                        <locName>
+
+  \                          <name xmlns=\"http://www.tei-c.org/ns/1.0\"
+  xml:lang=\"eng\">Baghdad</name>
+
+  \                        </locName>
+
+  \                        <alt>
+
+  \                          <name xmlns=\"http://www.tei-c.org/ns/1.0\"
+  xml:lang=\"eng\">Baghdad</name>
+
+  \                        </alt>
+
+  \                        <freq>1</freq>
+
+  \                      </r>
+
+  \                      <r type=\"geo\" xml:id=\"cairo_sample_01\">
+
+  \                        <loc>30°03'N 31°14'E</loc>
+
+  \                        <locName>
+
+  \                          <name xmlns=\"http://www.tei-c.org/ns/1.0\"
+  xml:lang=\"eng\">Cairo</name>
+
+  \                        </locName>
+
+  \                        <alt>
+
+  \                          <name xmlns=\"http://www.tei-c.org/ns/1.0\"
+  xml:lang=\"eng\">Cairo</name>
+
+  \                        </alt>
+
+  \                        <freq>1</freq>
+
+  \                      </r>
+
+  \                    </rs>
+
+  \        '404':
+
+  \          description: not found
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
+
+  \  /dict_api:
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: gets a specific html transformed via a specified xslt
+
+  \      operationId: getDictApi
+
+  \      description: |
+
+  \        By passing a well formed query and xslt you can retrieve ready to
+  display html
+
+  \      parameters:
+
+  \        - in: query
+
+  \          name: query
+
+  \          description: the query
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: dict
+
+  \          description: the dict id?
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: xslt
+
+  \          required: false
+
+  \          description: the filename of the xslt transformation (for
+  development purposes only)
+
+  \          schema:
+
+  \            type: string
+
+  \      responses:
+
+  \        '200':
+
+  \          description: the transformed html
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: div
+
+  \                  wrapped: false
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: >
+
+  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\"
+  xmlns:tei=\"http://www.tei-c.org/ns/1.0\">
+
+  \                    <div class=\"dvStats\" id=\"dvStats\">0&nbsp;hits</div>
+
+  \                    </div>
+
+  \        '500':
+
+  \          description: bad input parameter
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
+
+  \  /dict_index:
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: gets a specific html transformed via a specified xslt
+
+  \      operationId: getDictIndex
+
+  \      description: |
+
+  \        By passing a well formed query you can retrieve ready to display
+  html
+
+  \      parameters:
+
+  \        - in: query
+
+  \          name: dict
+
+  \          description: the dict id?
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: ind
+
+  \          required: true
+
+  \          description: I have no idea
+
+  \          schema:
+
+  \            type: string
+
+  \            enum:
+
+  \              - any
+
+  \              - lem
+
+  \              - infl
+
+  \              - en
+
+  \              - de
+
+  \              - fr
+
+  \              - pos
+
+  \              - root
+
+  \              - subc
+
+  \              - etymSrc
+
+  \              - etymLang
+
+  \        - in: query
+
+  \          name: str
+
+  \          required: true
+
+  \          description: the query string?
+
+  \          schema:
+
+  \            type: string
+
+  \      responses:
+
+  \        '200':
+
+  \          description: the transformed html
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: div
+
+  \                  wrapped: false
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: >
+
+  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\">
+
+  \                    <option class=\"opWordList_de\">'[abstauben]</option>
+
+  \                    <option class=\"opWordList_de\">[Abbilden]</option>
+
+  \                    <option class=\"opWordList_de\">[Abdruck]</option>
+
+  \                    <option class=\"opWordList_de\">[Abend]</option>
+
+  \                    <option class=\"opWordList_de\">[Abend]-</option>
+
+  \                    <option class=\"opWordList_de\">[Abendessen]</option>
+
+  \                    <option class=\"opWordList_de\">[Abendgebet]</option>
+
+  \                    <option class=\"opWordList_de\">[Abenteuer]</option>
+
+  \                    <option class=\"opWordList_de\">[Abfall]</option>
+
+  \                    <option class=\"opWordList_de\">[Abfallhaufen]</option>
+
+  \                    <option class=\"opWordList_de\">[Abflussloch]</option>
+
+  \                    <option class=\"opWordList_de\">[Abflussrinne]</option>
+
+  \                    <option class=\"opWordList_de\">[Abflussrohr]</option>
+
+  \                    <option class=\"opWordList_de\">[Abflußkanal]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[Abgeordnetenhaus]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[Abgeordnetenkammer]</option>
+
+  \                    <option class=\"opWordList_de\">[Abgeordneter]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[Abgeschiedenheit]</option>
+
+  \                    <option class=\"opWordList_de\">[Abitur]</option>
+
+  \                    <option class=\"opWordList_de\">[Abkürzung]</option>
+
+  \                    <option class=\"opWordList_de\">[Ablenkung]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[Ablflussrinne]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[Ablutionskännchen]</option>
+
+  \                    <option class=\"opWordList_de\">[Abmachung]</option>
+
+  \                    <option class=\"opWordList_de\">[Abort]</option>
+
+  \                    <option class=\"opWordList_de\">[Abortgrube]</option>
+
+  \                    <option class=\"opWordList_de\">[Absatz]</option>
+
+  \                    <option class=\"opWordList_de\">[Abscheu]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[Abscheulichkeit]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[Abschiedsgruß]</option>
+
+  \                    <option class=\"opWordList_de\">[Abschneiden]</option>
+
+  \                    <option class=\"opWordList_de\">[Abschnitt]</option>
+
+  \                    <option class=\"opWordList_de\">[Absender]</option>
+
+  \                    <option class=\"opWordList_de\">[Absicht]</option>
+
+  \                    <option class=\"opWordList_de\">[Abstand]</option>
+
+  \                    <option class=\"opWordList_de\">[Abstellbrett]</option>
+
+  \                    <option class=\"opWordList_de\">[Abstellraum]</option>
+
+  \                    <option class=\"opWordList_de\">[Abstieg]</option>
+
+  \                    <option class=\"opWordList_de\">[Abszess]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[Abteilungsleiter]</option>
+
+  \                    <option class=\"opWordList_de\">[Abtritt]</option>
+
+  \                    <option class=\"opWordList_de\">[Abwesenheit]</option>
+
+  \                    <option class=\"opWordList_de\">[Abwickeln]</option>
+
+  \                    <option class=\"opWordList_de\">[Abzweigung]</option>
+
+  \                    <option class=\"opWordList_de\">[abbiegen]</option>
+
+  \                    <option class=\"opWordList_de\">[abbrechen]</option>
+
+  \                    <option class=\"opWordList_de\">[abdecken]</option>
+
+  \                    <option class=\"opWordList_de\">[abendlich]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[abendländisch]</option>
+
+  \                    <option class=\"opWordList_de\">[aber]</option>
+
+  \                    <option class=\"opWordList_de\">[abfahren]</option>
+
+  \                    <option class=\"opWordList_de\">[abfangen]</option>
+
+  \                    <option class=\"opWordList_de\">[abgeben]</option>
+
+  \                    <option class=\"opWordList_de\">[abgebildet]</option>
+
+  \                    <option class=\"opWordList_de\">[abgenutzt]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[abgeschrieben]</option>
+
+  \                    <option class=\"opWordList_de\">[abgeschält]</option>
+
+  \                    <option class=\"opWordList_de\">[abgestempelt]</option>
+
+  \                    <option
+  class=\"opWordList_de\">[abgewirtschaftet]</option>
+
+  \                    <option class=\"opWordList_de\">[abhauen]</option>
+
+  \                    <option class=\"opWordList_de\">[abheben]</option>
+
+  \                    <option class=\"opWordList_de\">[abhäuten]</option>
+
+  \                    <option class=\"opWordList_de\">[ablehnen]</option>
+
+  \                    <option class=\"opWordList_de\">[abliefern]</option>
+
+  \                    <option class=\"opWordList_de\">[abmagern]</option>
+
+  \                    <option class=\"opWordList_de\">[abnehmen]</option>
+
+  \                    <option class=\"opWordList_de\">[abnormal]</option>
+
+  \                    <option class=\"opWordList_de\">[abreisen]</option>
+
+  \                    <option class=\"opWordList_de\">[abreißen]</option>
+
+  \                    <option class=\"opWordList_de\">[abschaben]</option>
+
+  \                    <option class=\"opWordList_de\">[abscheulich]</option>
+
+  \                    <option class=\"opWordList_de\">[abschlachten]</option>
+
+  \                    <option class=\"opWordList_de\">[abschneiden]</option>
+
+  \                    <option class=\"opWordList_de\">[abschreiben]</option>
+
+  \                    <option class=\"opWordList_de\">[abseihen]</option>
+
+  \                    <option class=\"opWordList_de\">[absengen]</option>
+
+  \                    <option class=\"opWordList_de\">[absichtlich]</option>
+
+  \                    <option class=\"opWordList_de\">[absteigen]</option>
+
+  \                    <option class=\"opWordList_de\">[abstoßen]</option>
+
+  \                    <option class=\"opWordList_de\">[abstreiten]</option>
+
+  \                    <option class=\"opWordList_de\">[abwaschen]</option>
+
+  \                    <option class=\"opWordList_de\">[abwesend]</option>
+
+  \                    <option class=\"opWordList_de\">[abwischen]</option>
+
+  \                    <option class=\"opWordList_de\">[abziehen]</option>
+
+  \                    <option class=\"opWordList_en\">[abdomen]</option>
+
+  \                    <option class=\"opWordList_en\">[abhorrence]</option>
+
+  \                    <option class=\"opWordList_en\">[ability]</option>
+
+  \                    <option class=\"opWordList_en\">[ablution]</option>
+
+  \                    <option class=\"opWordList_en\">[about]</option>
+
+  \                    <option class=\"opWordList_en\">[above]</option>
+
+  \                    <option class=\"opWordList_en\">[abroad]</option>
+
+  \                    <option class=\"opWordList_en\">[abscess]</option>
+
+  \                    <option class=\"opWordList_en\">[absence]</option>
+
+  \                    <option class=\"opWordList_en\">[absent]</option>
+
+  \                    <option class=\"opWordList_en\">[absolutely]</option>
+
+  \                    <option class=\"opWordList_en\">[abundantly]</option>
+
+  \                    <option class=\"opWordList_fr\">[abaissement]</option>
+
+  \                    <option class=\"opWordList_fr\">[abaisser]</option>
+
+  \                    <option class=\"opWordList_fr\">[abattage]</option>
+
+  \                    <option class=\"opWordList_fr\">[abattement]</option>
+
+  \                    <option class=\"opWordList_fr\">[abattre]</option>
+
+  \                    <option class=\"opWordList_fr\">[abattu]</option>
+
+  \                    <option class=\"opWordList_fr\">[abdomen]</option>
+
+  \                    <option class=\"opWordList_fr\">[abeilles]</option>
+
+  \                    <option class=\"opWordList_fr\">[ablution]</option>
+
+  \                    <option class=\"opWordList_fr\">[aboiement]</option>
+
+  \                    <option class=\"opWordList_fr\">[abonder]</option>
+
+  \                    <option class=\"opWordList_fr\">[aboyer]</option>
+
+  \                    <option class=\"opWordList_fr\">[abreuver]</option>
+
+  \                    <option class=\"opWordList_fr\">[abricots]</option>
+
+  \                    <option class=\"opWordList_fr\">[absence]</option>
+
+  \                    <option class=\"opWordList_fr\">[absent]</option>
+
+  \                    <option class=\"opWordList_fr\">[absolument]</option>
+
+  \                    <option class=\"opWordList_fr\">[absolutment]</option>
+
+  \                    <option class=\"opWordList_fr\">[abuser]</option>
+
+  \                    <option class=\"opWordList_fr\">[abîmé]</option>
+
+  \                    <option class=\"opWordList_de\">([Ab])hang</option>
+
+  \                    <option class=\"opWordList_de\">([Ab])wiegen</option>
+
+  \                    <option class=\"opWordList_de\">(Geld)
+  [abheben]</option>
+
+  \                    <option class=\"opWordList_de\">(Staub)
+  [abklopfen]</option>
+
+  \                    <option
+  class=\"opWordList_de\">(Unter-)[Abteilung]</option>
+
+  \                    <option class=\"opWordList_de\">(Zigarette)
+  [abaschen]</option>
+
+  \                    <option class=\"opWordList_de\">([ab])stützen</option>
+
+  \                    <option class=\"opWordList_de\">([ab])wägen</option>
+
+  \                    <option class=\"opWordList_de\">([ab]-)lecken</option>
+
+  \                    <option class=\"opWordList_de\">(edle)
+  [Abstammung]</option>
+
+  \                    <option class=\"opWordList_de\">(früher)
+  [Abend]</option>
+
+  \                    <option class=\"opWordList_de\">(gute)
+  [Absicht]</option>
+
+  \                    <option class=\"opWordList_de\">(stark)
+  [abnehmen]</option>
+
+  \                    <option class=\"opWordList_de\">[Abscheu]
+  erregen</option>
+
+  \                    <option class=\"opWordList_de\">[Abschied]
+  nehmen</option>
+
+  \                    <option class=\"opWordList_de\">Guten [Abend]!</option>
+
+  \                    <option class=\"opWordList_de\">Hau [ab]!</option>
+
+  \                    <option class=\"opWordList_de\">Luft
+  [ablassen]</option>
+
+  \                    <option class=\"opWordList_de\">Stimme
+  [abgeben]</option>
+
+  \                    <option class=\"opWordList_de\">[abendliche]
+  Feier</option>
+
+  \                    <option class=\"opWordList_de\">[aber]...nicht</option>
+
+  \                    <option class=\"opWordList_de\">[abgehen]
+  (Zug)</option>
+
+  \                    <option class=\"opWordList_de\">[abgenützt]
+  werden</option>
+
+  \                    <option class=\"opWordList_de\">[abgerissenes]
+  Kleidungsstück</option>
+
+  \                    <option class=\"opWordList_de\">[abgeschnittene]
+  Locke</option>
+
+  \                    <option class=\"opWordList_de\">[abgesehen]
+  davon</option>
+
+  \                    <option class=\"opWordList_de\">[abgesehen]
+  von</option>
+
+  \                    <option class=\"opWordList_de\">[abheben]
+  (Geld)</option>
+
+  \                    <option class=\"opWordList_de\">[abhängen] von</option>
+
+  \                    <option class=\"opWordList_de\">[abhängig] von</option>
+
+  \                    <option class=\"opWordList_de\">[abhören]
+  (Patient)</option>
+
+  \                    <option class=\"opWordList_de\">[ablassen] von</option>
+
+  \                    <option class=\"opWordList_de\">[abschleppen]
+  (Auto)</option>
+
+  \                    <option class=\"opWordList_de\">[abspülen]
+  (Geschirr)</option>
+
+  \                    <option class=\"opWordList_de\">[abstürzen]
+  (Computer</option>
+
+  \                    <option class=\"opWordList_de\">[abtrünniger]
+  Muslim</option>
+
+  \                    <option class=\"opWordList_de\">[abwesend]
+  sein</option>
+
+  \                    <option class=\"opWordList_de\">[abzielen] auf</option>
+
+  \                    <option class=\"opWordList_de\">en [abondance]</option>
+
+  \                    <option class=\"opWordList_de\">etw.
+  [abbrechen]</option>
+
+  \                    <option class=\"opWordList_de\">etw.
+  [abkratzen]</option>
+
+  \                    <option class=\"opWordList_de\">gegen [Abend]</option>
+
+  \                    <option class=\"opWordList_de\">heute [Abend]</option>
+
+  \                    <option class=\"opWordList_de\">langsam
+  [abfließen]</option>
+
+  \                    <option class=\"opWordList_de\">mit [Absicht]</option>
+
+  \                    <option class=\"opWordList_de\">nun [aber]</option>
+
+  \                    <option class=\"opWordList_de\">sich [abmühen]</option>
+
+  \                    <option class=\"opWordList_de\">vorgestern
+  [Abend]</option>
+
+  \                    <option class=\"opWordList_en\">[about] what</option>
+
+  \                    <option class=\"opWordList_en\">[absolutely]
+  nothing</option>
+
+  \                    <option class=\"opWordList_en\">caring [about]</option>
+
+  \                    <option class=\"opWordList_en\">from [above]</option>
+
+  \                    <option class=\"opWordList_en\">from [abroad]</option>
+
+  \                    <option class=\"opWordList_en\">to [abandon]</option>
+
+  \                    <option class=\"opWordList_en\">to [abound]</option>
+
+  \                    <option class=\"opWordList_en\">to [abuse]</option>
+
+  \                    <option class=\"opWordList_fr\">[aborder] qc.</option>
+
+  \                    <option class=\"opWordList_fr\">[abîmer] qc.</option>
+
+  \                    <option class=\"opWordList_fr\">d'[abord]</option>
+
+  \                    <option class=\"opWordList_fr\">devenir
+  [abondant]</option>
+
+  \                    <option class=\"opWordList_fr\">d’[abord]</option>
+
+  \                    <option class=\"opWordList_fr\">règle
+  [absolue]</option>
+
+  \                    <option class=\"opWordList_fr\">s’[abîmer]</option>
+
+  \                    <option class=\"opWordList_fr\">être
+  [abandonné]</option>
+
+  \                    <option class=\"opWordList_fr\">être [absent]</option>
+
+  \                    <option class=\"opWordList_de\">([ab])wiegen
+  (Gewicht)</option>
+
+  \                    <option class=\"opWordList_de\">(die Schule/ das
+  Studium) [abschließen]/[absolvieren]</option>
+
+  \                    <option class=\"opWordList_de\">[Ablegen] von
+  Gegenständen</option>
+
+  \                    <option class=\"opWordList_de\">[Abreibung] (mit
+  Seife)</option>
+
+  \                    <option class=\"opWordList_de\">[Abweichung] (vom
+  Rechten)</option>
+
+  \                    <option class=\"opWordList_de\">[abgerissenes]
+  zerlumptes Kleidungsstück</option>
+
+  \                    <option class=\"opWordList_de\">[abgewickelt] werden
+  (Geschäft)</option>
+
+  \                    <option class=\"opWordList_de\">[abhängig] sein
+  von</option>
+
+  \                    <option class=\"opWordList_de\">[abnehmen] (den
+  Telefonhörer)</option>
+
+  \                    <option class=\"opWordList_de\">an jenem
+  [Abend]</option>
+
+  \                    <option class=\"opWordList_de\">austreten (auf
+  [Abort])</option>
+
+  \                    <option class=\"opWordList_de\">das Fell
+  [abziehen]</option>
+
+  \                    <option class=\"opWordList_de\">die [Absicht]
+  habend...</option>
+
+  \                    <option class=\"opWordList_de\">eine [Abteilung]
+  Soldaten</option>
+
+  \                    <option class=\"opWordList_de\">mit der
+  [Absicht]</option>
+
+  \                    <option class=\"opWordList_de\">sich (gegenseitig)
+  [abküssen]</option>
+
+  \                    <option class=\"opWordList_de\">sich [abwenden]
+  von</option>
+
+  \                    <option class=\"opWordList_de\">sich [abzeichnend]
+  (Konturen)</option>
+
+  \                    <option class=\"opWordList_de\">von ihm
+  [abfallen]</option>
+
+  \                    <option class=\"opWordList_de\">zu [Abend]
+  essen</option>
+
+  \                    <option class=\"opWordList_de\">zu [Abend]
+  speisen</option>
+
+  \                    <option class=\"opWordList_en\">hanging
+  [about]/around</option>
+
+  \                    <option class=\"opWordList_en\">to [abandon]
+  sth.</option>
+
+  \                    <option class=\"opWordList_en\">to [abate]
+  (price)</option>
+
+  \                    <option class=\"opWordList_en\">to be
+  [abandoned]</option>
+
+  \                    <option class=\"opWordList_en\">to be [able]</option>
+
+  \                    <option class=\"opWordList_en\">to be [absent]</option>
+
+  \                    <option class=\"opWordList_en\">to complain
+  [about]</option>
+
+  \                    <option class=\"opWordList_en\">to laze
+  ([about])</option>
+
+  \                    <option class=\"opWordList_en\">to reflect
+  ([about])</option>
+
+  \                    <option class=\"opWordList_en\">to strut
+  [about]</option>
+
+  \                    <option class=\"opWordList_en\">to think
+  ([about])</option>
+
+  \                    <option class=\"opWordList_en\">to worry
+  [about]</option>
+
+  \                    <option class=\"opWordList_en\">wandering
+  [about]/around</option>
+
+  \                    <option class=\"opWordList_fr\">[abandonner]
+  qn./qc.</option>
+
+  \                    <option class=\"opWordList_fr\">[abri] de
+  fortune</option>
+
+  \                    <option class=\"opWordList_fr\">ne... [absolument]
+  personne</option>
+
+  \                    <option class=\"opWordList_fr\">s'[abattre]
+  sur</option>
+
+  \                    <option class=\"opWordList_fr\">s’[absenter]
+  (de)</option>
+
+  \                    <option class=\"opWordList_fr\">tout d'[abord]</option>
+
+  \                    <option class=\"opWordList_de\">[Absatz]/Stöckel der
+  Schuhe</option>
+
+  \                    <option class=\"opWordList_de\">[Abzug] (e-r
+  Feuerwaffe)</option>
+
+  \                    <option class=\"opWordList_de\">[Abzugsloch] unter der
+  Feuerstelle</option>
+
+  \                    <option class=\"opWordList_de\">[abgeschnittene] Locke
+  der Braut</option>
+
+  \                    <option class=\"opWordList_de\">[abgewinkelter]
+  Eingangsbereich tunesischer Häuser</option>
+
+  \                    <option class=\"opWordList_de\">[abschätziger] und
+  verächtlicher Mann</option>
+
+  \                    <option class=\"opWordList_de\">[abschüssige](r)
+  Straße/ Weg</option>
+
+  \                    <option class=\"opWordList_de\">des [Ablegens] von
+  Kleidung</option>
+
+  \                    <option class=\"opWordList_de\">die den Kachelfries
+  [abschließt]</option>
+
+  \                    <option class=\"opWordList_de\">eine große Schau
+  [abziehen]</option>
+
+  \                    <option class=\"opWordList_de\">j-m etw.
+  [abknöpfen]</option>
+
+  \                    <option class=\"opWordList_de\">j-m etw.
+  [abluchsen]</option>
+
+  \                    <option class=\"opWordList_de\">mit j-m
+  [abrechnen]</option>
+
+  \                    <option class=\"opWordList_en\">it is [absolutely]
+  necessary</option>
+
+  \                    <option class=\"opWordList_en\">to be passionate
+  [about]</option>
+
+  \                    <option class=\"opWordList_en\">to become
+  [abundant]/plentiful</option>
+
+  \                    <option class=\"opWordList_en\">to hang
+  [about]/around</option>
+
+  \                    <option class=\"opWordList_en\">to philosophize [about]
+  sth.</option>
+
+  \                    <option class=\"opWordList_en\">to wander
+  [about]/around</option>
+
+  \                    <option class=\"opWordList_fr\">avoir l'esprit
+  [absent]</option>
+
+  \                    <option class=\"opWordList_fr\">chevelure [abondante]
+  et indisciplinée</option>
+
+  \                    <option class=\"opWordList_fr\">il est [absolument]
+  necessaire</option>
+
+  \                    <option class=\"opWordList_de\">Schuheisen (für Spitze
+  und [Absatz])</option>
+
+  \                    <option class=\"opWordList_de\">Unterleder von Sohle
+  und [Absatz]</option>
+
+  \                    <option class=\"opWordList_de\">Wasch- und Wasserstelle
+  sowie [Abort]</option>
+
+  \                    <option class=\"opWordList_de\">[aber] geduldete)
+  Zuschauerin (bei Familienfeiern)</option>
+
+  \                    <option class=\"opWordList_de\">[abmessen] (mit e-m
+  Hohlmaß</option>
+
+  \                    <option class=\"opWordList_de\">an den Festtagen
+  Verwandtschaftsbesuche [absolviert])</option>
+
+  \                    <option class=\"opWordList_de\">befreien (verstopften
+  Gang/Kanal/[Abfluss]</option>
+
+  \                    <option class=\"opWordList_de\">der die einheimischen
+  Märkte [abmacht]</option>
+
+  \                    <option class=\"opWordList_de\">die das Trauerjahr
+  [abschließende] Zeremonie</option>
+
+  \                    <option class=\"opWordList_de\">mittels e-s Schlosses
+  [ab]-</option>
+
+  \                    <option class=\"opWordList_en\">to acquire knowledge
+  [about] sth.</option>
+
+  \                    <option class=\"opWordList_en\">to gossip [about]
+  sb./sth.</option>
+
+  \                    <option class=\"opWordList_en\">to perform the ritual
+  [ablution]</option>
+
+  \                    <option class=\"opWordList_en\">to talk [about]
+  sth./sb.</option>
+
+  \                    <option class=\"opWordList_de\">Feier zur schriftlichen
+  [Abfassung] eines Heiratsübereinkommens</option>
+
+  \                    <option class=\"opWordList_de\">Student bzw.
+  [Absolvent] der Zitouna-Hochschule</option>
+
+  \                    <option class=\"opWordList_de\">bei einer Prüfung
+  schummeln oder [abschreiben]</option>
+
+  \                    <option class=\"opWordList_de\">den Kuskusdämpfer
+  mittels der qfīla [abdichten]</option>
+
+  \                    <option class=\"opWordList_de\">sich [absichern] (durch
+  Rücklagen o. ä.)</option>
+
+  \                    <option class=\"opWordList_en\">to doubt of/[about]
+  sth./sb.</option>
+
+  \                    <option class=\"opWordList_fr\">employer [abondamment]
+  le mot pénis (zibb)</option>
+
+  \                    <option class=\"opWordList_de\">die als [Abgrenzung]
+  einer landwirtschaftlichen Fläche dienen</option>
+
+  \                    <option class=\"opWordList_de\">die gerne [abends]
+  ausgeht und gerne feiert</option>
+
+  \                    <option class=\"opWordList_de\">eifersüchtig auf die
+  [Abgeschlossenheit] seiner Frau Bedachter</option>
+
+  \                    <option class=\"opWordList_en\">a unit of mass ([about]
+  5 g)</option>
+
+  \                    <option class=\"opWordList_en\">to [abundantly] use the
+  word penis (zibb)</option>
+
+  \                    <option class=\"opWordList_en\">to say bad things
+  [about] sb./sth.</option>
+
+  \                    <option class=\"opWordList_de\">[aber] von Männern wie
+  Frauen unter sich gebraucht)</option>
+
+  \                    <option class=\"opWordList_de\">die Verbindung/den
+  Kontakt zu j-m [abbrechen]</option>
+
+  \                    <option class=\"opWordList_de\">bezüglich auf einen
+  Studenten bzw. [Absolventen] der Zitouna-Hochschule</option>
+
+  \                    <option class=\"opWordList_de\">das Fell von
+  Schlachttieren (an Schädel und Läufen) [absengen]</option>
+
+  \                    <option class=\"opWordList_en\">What do I/do you/does
+  he etc. think ([about]...)?</option>
+
+  \                    <option class=\"opWordList_de\">sehr feine und
+  geschmeidige Pantoffel mit [abgerundeter] Spitze und aus Kamelleder</option>
+
+  \                    <option class=\"opWordList_de\">und 9. Tag nach einem
+  Todesfall der leidtragenden Familie [abstattete] (obsoleter Brauch)</option>
+
+  \                    </div>
+
+  \        '500':
+
+  \          description: bad input parameter
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
+
+  \  /corpus:\ 
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: Search corpus
+
+  \      operationId: searchCorpus
+
+  \      description: |
+
+  \        By passing a well formed noSKE query as 'query' parameter, you can
+  retrieve serach results
+
+  \      parameters:
+
+  \        - in: query
+
+  \          name: query
+
+  \          description: query to perform against NoSKE
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: print
+
+  \          required: false
+
+  \          description: 'Whether to retrieve a full HTML file with
+  printer-friendly formatting.'
+
+  \          schema:
+
+  \            type: string
+
+  \      responses:
+
+  \        '200':
+
+  \          description: the transformed html
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: div
+
+  \                  wrapped: false
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: >\ 
+
+  \                    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+
+  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\"
+  xmlns:acdh=\"http://acdh.oeaw.ac.at\"
+  xmlns:tei=\"http://www.tei-c.org/ns/1.0\" class=\"corpus-search-results\">
+
+  \                        <h2 xml:space=\"preserve\">Search results for
+  dār</h2>
+
+  \                        <div class=\"corpus-search-result\"
+  id=\"corpus-w-URFA-077_xTok_001078\">
+
+  \                            <div class=\"left\">
+
+  \                                <span class=\"w\"
+  id=\"URFA-077_xTok_001071\">āni</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-077_xTok_001072\">nāyim</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-077_xTok_001073\">hēne</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-077_xTok_001074\">b</span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-077_xTok_001076\">ad</span>
+
+  \                            </div>
+
+  \                            <div class=\"keyword\">
+
+  \                                <span class=\"w\">dār</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                            </div>
+
+  \                            <div class=\"right\">
+
+  \                                <span class=\"w\">haḏiyye</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\">nāyim</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                            </div>
+
+  \                        </div>
+
+  \                        <div class=\"corpus-search-result\"
+  id=\"corpus-w-URFA-115_xTok_000096\">
+
+  \                            <div class=\"left\">
+
+  \                                <span class=\"w\"
+  id=\"URFA-115_xTok_000087\">rəḥalaw</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-115_xTok_000089\">xall</span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-115_xTok_000091\">ō</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-115_xTok_000092\">b</span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-115_xTok_000094\">ad</span>
+
+  \                            </div>
+
+  \                            <div class=\"keyword\">
+
+  \                                <span class=\"w\">dār</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                            </div>
+
+  \                            <div class=\"right\">
+
+  \                                <span class=\"w\">w</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\">šālaw</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\">eger</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\">miṯil</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\">al</span>
+
+  \                            </div>
+
+  \                        </div>
+
+  \                        <div class=\"corpus-search-result\"
+  id=\"corpus-w-URFA-122_xTok_000738\">
+
+  \                            <div class=\"left\">
+
+  \                                <span class=\"w\"
+  id=\"URFA-122_xTok_000730\">u</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-122_xTok_000731\">ˀal</span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-122_xTok_000733\">bāb</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-122_xTok_000734\">b</span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-122_xTok_000736\">ad</span>
+
+  \                            </div>
+
+  \                            <div class=\"keyword\">
+
+  \                                <span class=\"w\">dār</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                            </div>
+
+  \                            <div class=\"right\">
+
+  \                                <span class=\"w\">imčallṭīn</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\">al</span>
+
+  \                                <span class=\"w\">qīrān</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\">aṭ</span>
+
+  \                                <span class=\"w\">ṭūg</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                            </div>
+
+  \                        </div>
+
+  \                        <div class=\"corpus-search-result\"
+  id=\"corpus-w-URFA-125_xTok_000258\">
+
+  \                            <div class=\"left\">
+
+  \                                <span class=\"w\"
+  id=\"URFA-125_xTok_000253\">hēn</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-125_xTok_000254\">ṛāyiḥ</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-125_xTok_000255\">āni</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-125_xTok_000256\">ˀarīd</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\"
+  id=\"URFA-125_xTok_000257\">agḏ̣ub</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                            </div>
+
+  \                            <div class=\"keyword\">
+
+  \                                <span class=\"w\">dār</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                            </div>
+
+  \                            <div class=\"right\">
+
+  \                                <span class=\"w\">aš</span>
+
+  \                                <span class=\"w\">šēx</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\">w</span>
+
+  \                                <span class=\"w\">arīd</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                                <span class=\"w\">āni</span>
+
+  \                                <span xml:space=\"preserve\"></span>
+
+  \                            </div>
+
+  \                        </div>
+
+  \                    </div>
+
+  \        '500':
+
+  \          description: bad input parameter
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
+
+  \  /corpus_text:\ 
+
+  \    get:
+
+  \      tags:
+
+  \        - noauth
+
+  \      summary: Get rendered corpus text
+
+  \      operationId: getCorpusText
+
+  \      description: |
+
+  \        A pageable set of corpus utterances from the given text.
+
+  \      parameters:
+
+  \        - in: query
+
+  \          name: id
+
+  \          description: Corpus text ID
+
+  \          required: true
+
+  \          schema:
+
+  \            type: string
+
+  \        - in: query
+
+  \          name: size
+
+  \          required: false
+
+  \          description: 'How many results to retrieve in one query. Defaults
+  to 10.'
+
+  \          schema:
+
+  \            type: number
+
+  \            default: 10
+
+  \        - in: query
+
+  \          name: page
+
+  \          required: false
+
+  \          description: 'Page number to retrieve. Defaults to 1.'
+
+  \          schema:
+
+  \            type: number
+
+  \            default: 1
+
+  \        - in: query
+
+  \          name: print
+
+  \          required: false
+
+  \          description: 'Whether to retrieve a full HTML file with
+  printer-friendly formatting.'
+
+  \          schema:
+
+  \            type: string
+
+  \      responses:
+
+  \        '200':
+
+  \          description: the transformed html
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \                xml:
+
+  \                  name: div
+
+  \                  wrapped: false
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: >\ 
+
+  \                    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+
+  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\"
+  xmlns:acdh=\"http://acdh.oeaw.ac.at\"
+  xmlns:tei=\"http://www.tei-c.org/ns/1.0\" class=\"corpus-utterances\">
+
+  \                        <div class=\"u\" id=\"URFA-011_a3\">
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000075\">al</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000077\">gabǝr</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000078\">baʕdēn</span>
+
+  \                            <span class=\"pc\" id=\"xTok_000079\">,</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000080\">ʕugub</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000081\">sabʕ</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000082\">ᵊsnīn</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000083\">yigdarūn</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000084\">yḥuṭṭūn</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000085\">qēr</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000086\">wāḥad</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000087\">bī</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000089\">´</span>
+
+  \                            <span class=\"pc\" id=\"xTok_000090\">.</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000091\">in</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000092\">mā</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000093\">ṣār</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000094\">sabʕ</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000095\">ᵊsnīn</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000096\">qēr</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000097\">wāḥad</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000098\">mā</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000099\">yḥuṭṭūn</span>
+
+  \                            <span class=\"pc\" id=\"xTok_000100\">.</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                        </div>
+
+  \                        <div class=\"u\" id=\"URFA-011_a4\">
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000101\">ta</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000103\">ngūl</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000104\">hāḏa</span>
+
+  \                            <span class=\"pc\" id=\"xTok_000105\">,</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000106\">mayyit</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000107\">luwwa</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000108\">sine</span>
+
+  \                            <span class=\"pc\" id=\"xTok_000109\">,</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000110\">al</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000112\">gabǝr</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000113\">hāḏa</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000114\">mā</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000115\">yiftaḥūn</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000117\">u</span>
+
+  \                            <span class=\"pc\" id=\"xTok_000118\">–</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000119\">mā</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000120\">yiftaḥūn</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000122\">u</span>
+
+  \                            <span class=\"pc\" id=\"xTok_000123\">–</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000124\">baˁad</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000125\">sabˁ</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000126\">ᵊsnīn</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000127\">yiftaḥūn</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000129\">u</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000130\">yigdarūn</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000131\">in</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000132\">māt</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000133\">ḥade</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000134\">in</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000135\">ṣār</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000136\">mayyit</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000137\">uxṛa</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000138\">l</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000140\">al</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000142\">ˁēle</span>
+
+  \                            <span class=\"pc\" id=\"xTok_000143\">,</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000144\">kull</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000146\">min</span>
+
+  \                            <span class=\"pc\" id=\"xTok_000147\">…</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000148\">ta</span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000150\">ngūl</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000151\">alḥaz</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                            <span class=\"w\"
+  id=\"URFA-011_xTok_000152\">iḥna</span>
+
+  \                            <span xml:space=\"preserve\"></span>
+
+  \                        </div>
+
+  \                    </div>
+
+  \        '500':
+
+  \          description: bad input parameter
+
+  \          content:
+
+  \            application/xml:
+
+  \              schema:
+
+  \                type: string
+
+  \              examples:
+
+  \                html:
+
+  \                  summary: A sample HTML response
+
+  \                  value: '<html><body><ul><li>item 1</li><li>item
+  2</li></ul></body></html>'
 
   components:
-    schemas:
-      ProjectConfig:
-        type: object
-        properties:
-          projectConfig:
-            $ref: '#/components/schemas/projectConfig_type'
-      projectConfig_type:
-        type: object
-        properties:
-          title:
-            type: string
-          logo:
-            $ref: '#/components/schemas/logo_type'
-          param:
-            $ref: '#/components/schemas/param_type'
-          panel:
-            $ref: '#/components/schemas/panel_type'
-          menu:
-            $ref: '#/components/schemas/menu_type'          
-      logo_type:
-        type: object
-        properties:
-          img:
-            type: string
-      param_type:
-        type: array
-        minItems: 0
-        items:
-          type: string
-      panel_type:
-        type: array
-        minItems: 0
-        items:
-          type: object
-          properties:
-            type:
-              type: string
-            target:
-              type: string
-            title:
-              type: string
-          required:
-          - type
-          - title
-          - target
-      item_type:
-        type: array
-        minItems: 0
-        items:
-          type: object
-          properties:
-            id:
-              type: string
-            title:
-              type: string
-            type:
-              type: string
-              enum:
-              - item
-              - separator
-            componentName:
-              type: string
-              enum:
-              - WMap
-              - DictQuery
-              - CrossDictQuery
-              - BiblioQuery
-              - Text
-              - SampleText
-              - DataList
-          required:
-          - type
-      main_type:
-        type: array
-        minItems: 0
-        items:
-          type: object
-          properties:
-            id:
-              type: string
-            title:
-              type: string
-            item:
-              $ref: '#/components/schemas/item_type'
-            type:
-              type: string
-              enum:
-              - dropdown
-          required:
-          - item
-          - id
-          - title
-          - type
-      subnav_type:
-        type: array
-        minItems: 0
-        items:
-          type: object
-          properties:
-            id:
-              type: string
-            class:
-              type: string
-            title:
-              type: string
-            type:
-              type: string
-          required:
-          - id
-          - title
-          - type
-      menu_type:
-        type: object
-        properties:
-          main:
-            $ref: '#/components/schemas/main_type'
-          subnav:
-            $ref: '#/components/schemas/subnav_type'
-      Feature:
-        title: GeoJSON Feature
-        type: object
-        required:
-        - type
-        - properties
-        - geometry
-        properties:
-          type:
-            type: string
-            enum:
-            - Feature
-          id:
-            oneOf:
-            - type: number
-            - type: string
-          properties:
-            oneOf:
-            - type: 'null'
-            - type: object
-          geometry:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/Point'    
-      Point:
-        title: GeoJSON Point
-        type: object
-        required:
-        - type
-        - coordinates
-        properties:
-          type:
-            type: string
-            enum:
-            - Point
-          coordinates:
-            type: array
-            minItems: 2
-            items:
-              type: number
-          bbox:
-            type: array
-            minItems: 4
-            items:
-              type: number
+
+  \  schemas:
+
+  \    ProjectConfig:
+
+  \      type: object
+
+  \      properties:
+
+  \        projectConfig:
+
+  \          $ref: '#/components/schemas/projectConfig_type'
+
+  \    projectConfig_type:
+
+  \      type: object
+
+  \      properties:
+
+  \        title:
+
+  \          type: string
+
+  \        logo:
+
+  \          $ref: '#/components/schemas/logo_type'
+
+  \        param:
+
+  \          $ref: '#/components/schemas/param_type'
+
+  \        panel:
+
+  \          $ref: '#/components/schemas/panel_type'
+
+  \        menu:
+
+  \          $ref: '#/components/schemas/menu_type'         \ 
+
+  \    logo_type:
+
+  \      type: object
+
+  \      properties:
+
+  \        img:
+
+  \          type: string
+
+  \    param_type:
+
+  \      type: array
+
+  \      minItems: 0
+
+  \      items:
+
+  \        type: string
+
+  \    panel_type:
+
+  \      type: array
+
+  \      minItems: 0
+
+  \      items:
+
+  \        type: object
+
+  \        properties:
+
+  \          type:
+
+  \            type: string
+
+  \          target:
+
+  \            type: string
+
+  \          title:
+
+  \            type: string
+
+  \        required:
+
+  \        - type
+
+  \        - title
+
+  \        - target
+
+  \    item_type:
+
+  \      type: array
+
+  \      minItems: 0
+
+  \      items:
+
+  \        type: object
+
+  \        properties:
+
+  \          id:
+
+  \            type: string
+
+  \          title:
+
+  \            type: string
+
+  \          type:
+
+  \            type: string
+
+  \            enum:
+
+  \            - item
+
+  \            - separator
+
+  \          componentName:
+
+  \            type: string
+
+  \            enum:
+
+  \            - WMap
+
+  \            - DictQuery
+
+  \            - CrossDictQuery
+
+  \            - BiblioQuery
+
+  \            - Text
+
+  \            - SampleText
+
+  \            - DataList
+
+  \            - CorpusQuery
+
+  \        required:
+
+  \        - type
+
+  \    main_type:
+
+  \      type: array
+
+  \      minItems: 0
+
+  \      items:
+
+  \        type: object
+
+  \        properties:
+
+  \          id:
+
+  \            type: string
+
+  \          title:
+
+  \            type: string
+
+  \          item:
+
+  \            $ref: '#/components/schemas/item_type'
+
+  \          type:
+
+  \            type: string
+
+  \            enum:
+
+  \            - dropdown
+
+  \        required:
+
+  \        - item
+
+  \        - id
+
+  \        - title
+
+  \        - type
+
+  \    subnav_type:
+
+  \      type: array
+
+  \      minItems: 0
+
+  \      items:
+
+  \        type: object
+
+  \        properties:
+
+  \          id:
+
+  \            type: string
+
+  \          class:
+
+  \            type: string
+
+  \          title:
+
+  \            type: string
+
+  \          type:
+
+  \            type: string
+
+  \        required:
+
+  \        - id
+
+  \        - title
+
+  \        - type
+
+  \    menu_type:
+
+  \      type: object
+
+  \      properties:
+
+  \        main:
+
+  \          $ref: '#/components/schemas/main_type'
+
+  \        subnav:
+
+  \          $ref: '#/components/schemas/subnav_type'
+
+  \    Feature:
+
+  \      title: GeoJSON Feature
+
+  \      type: object
+
+  \      required:
+
+  \      - type
+
+  \      - properties
+
+  \      - geometry
+
+  \      properties:
+
+  \        type:
+
+  \          type: string
+
+  \          enum:
+
+  \          - Feature
+
+  \        id:
+
+  \          oneOf:
+
+  \          - type: number
+
+  \          - type: string
+
+  \        properties:
+
+  \          oneOf:
+
+  \          - type: 'null'
+
+  \          - type: object
+
+  \        geometry:
+
+  \          oneOf:
+
+  \          - type: 'null'
+
+  \          - $ref: '#/components/schemas/Point'   \ 
+
+  \    Point:
+
+  \      title: GeoJSON Point
+
+  \      type: object
+
+  \      required:
+
+  \      - type
+
+  \      - coordinates
+
+  \      properties:
+
+  \        type:
+
+  \          type: string
+
+  \          enum:
+
+  \          - Point
+
+  \        coordinates:
+
+  \          type: array
+
+  \          minItems: 2
+
+  \          items:
+
+  \            type: number
+
+  \        bbox:
+
+  \          type: array
+
+  \          minItems: 4
+
+  \          items:
+
+  \            type: number
+
+  \           \ 
+
+  \           "
 contentType: yaml

--- a/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
+++ b/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
@@ -1,4617 +1,2029 @@
 _id: spc_8ea7cfbb1b844196a75f9766a024be57
 type: ApiSpec
 parentId: wrk_6915256f54c24d51aa934588fd7b49ff
-modified: 1692615750781
+modified: 1695056474462
 created: 1675182326019
 fileName: Current Vicav API 1.0.0
-contents: "openapi: 3.1.0
+contents: >-
+  openapi: 3.1.0
 
   jsonSchemaDialect: 'https://spec.openapis.org/oas/3.1/dialect/base'
 
   servers:
-
-  \  - url: https://vicav.acdh.oeaw.ac.at
-
-  \    description: \"current ACDH-CH prod server\"
-
-  \  - url: https://vicav.acdh-ch-dev.oeaw.ac.at/vicav
-
-  \    description: \"current ACDH-CH dev server\"
-
-  \  - url: https://vicav.acdh-ch-dev.oeaw.ac.at/vicav
-
-  \    description: \"current ACDH-CH dev server\"
-
-  \  # Added by API Auto Mocking Plugin
-
-  \  - description: SwaggerHub API Auto Mocking
-
-  \    url: https://virtserver.swaggerhub.com/ctot-nondef/Vicav/1.0.0
-
-  \  - url: http://localhost:8984/vicav
-
-  \    description: \"local development\"
-
-  \  - url: http://shawi-local.acdh.oeaw.ac.at:8984/vicav
-
-  \    description: \"local development\"
-
+    - url: https://vicav.acdh.oeaw.ac.at
+      description: "current ACDH-CH prod server"
+    - url: https://vicav.acdh-ch-dev.oeaw.ac.at
+      description: "current ACDH-CH dev server"
+    - url: https://vicav.acdh-ch-dev.oeaw.ac.at
+      description: "current ACDH-CH dev server"
+    # Added by API Auto Mocking Plugin
+    - description: SwaggerHub API Auto Mocking
+      url: https://virtserver.swaggerhub.com/ctot-nondef/Vicav/1.0.0
+    - url: http://localhost:8984
+      description: "local development"
+    - url: http://shawi-local.acdh.oeaw.ac.at:8984
+      description: "local development"
   info:
-
-  \  description: This is the currently implemented vicav API
-
-  \  version: \"1.0.0\"
-
-  \  title: Current Vicav API
-
-  \  contact:
-
-  \    email: christoph.hoffmann@oeaw.ac.at
-
-  \  license:
-
-  \    name: MIT
-
-  \    url: 'https://opensource.org/licenses/MIT'
-
+    description: This is the currently implemented vicav API
+    version: "1.0.0"
+    title: Current Vicav API
+    contact:
+      email: christoph.hoffmann@oeaw.ac.at
+    license:
+      name: MIT
+      url: 'https://opensource.org/licenses/MIT'
   tags:
-
-  \  - name: noauth
-
-  \    description: Operations available without authentication
-
+    - name: noauth
+      description: Operations available without authentication
   paths:
-
-  \  /project:
-
-  \    get:
-
-  \      description: Get info about the project, menus and open
-  panels/windows
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: gets basic project configuration
-
-  \      operationId: getProject
-
-  \      responses:
-
-  \        '200':
-
-  \          description: an xml with wrapped html contained
-
-  \          content:
-
-  \            application/json:
-
-  \              schema:
-
-  \                $ref: '#/components/schemas/ProjectConfig'
-
-  \              examples:
-
-  \                project_config_JSON:
-
-  \                  summary: the project configuration
-
-  \                  value: {
-
-  \                    \"projectConfig\": {
-
-  \                      \"title\": \"VICAV3.0 - Vienna Corpus of Arabic
-  Varieties\",
-
-  \                      \"logo\": {
-
-  \                        \"img\": \"images\\/vicav_logo.svg\"
-
-  \                      },
-
-  \                      \"param\": [
-
-  \                        \".*\",
-
-  \                        \"geo\"
-
-  \                      ],
-
-  \                      \"panel\": [
-
-  \                        {
-
-  \                          \"type\": \"text\",
-
-  \                          \"target\": \"li_vicavMission\",
-
-  \                          \"title\": \"MISSION\"
-
-  \                        },
-
-  \                        {
-
-  \                          \"type\": \"text\",
-
-  \                          \"target\": \"li_vicavNews\",
-
-  \                          \"title\": \"NEWS\"
-
-  \                        }
-
-  \                      ],
-
-  \                      \"menu\": {
-
-  \                        \"main\": [
-
-  \                          {
-
-  \                            \"id\": \"dropdown00\",
-
-  \                            \"title\": \"Project\",
-
-  \                            \"item\": [
-
-  \                              {
-
-  \                                \"id\": \"li_vicavMission\",
-
-  \                                \"title\": \"Mission\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavNews\",
-
-  \                                \"title\": \"News\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavTypesOfText\",
-
-  \                                \"title\": \"Types of Text\\/Data\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavContributors\",
-
-  \                                \"title\": \"Contributors\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavLinguistics\",
-
-  \                                \"title\": \"Linguistics\",
-
-  \                                \"type\": \"item\"
-
-  \                              }
-
-  \                            ],
-
-  \                            \"type\": \"dropdown\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"dropdown01\",
-
-  \                            \"title\": \"Bibliographies\",
-
-  \                            \"item\": [
-
-  \                              {
-
-  \                                \"id\":
-  \"li_vicavExplanationBibliography\",
-
-  \                                \"title\": \"Explanation\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"navBiblGeoMarkers\",
-
-  \                                \"title\": \"All Bibl. Locations on Map\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"navBiblRegMarkers\",
-
-  \                                \"title\": \"All Bibl. Regions on Map\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"navDictGeoRegMarkers\",
-
-  \                                \"title\": \"All Dictionaries in Bibl. on
-  Map\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"navTextbookGeoRegMarkers\",
-
-  \                                \"title\": \"All Textbooks in Bibl. on
-  Map\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"liBiblNewQuery\",
-
-  \                                \"title\": \"Query Bibliography\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavContributeBibliography\",
-
-  \                                \"title\": \"Contribute to the
-  Bibliography\",
-
-  \                                \"type\": \"item\"
-
-  \                              }
-
-  \                            ],
-
-  \                            \"type\": \"dropdown\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"dropdown02\",
-
-  \                            \"title\": \"Profiles\",
-
-  \                            \"item\": [
-
-  \                              {
-
-  \                                \"id\": \"li_vicavExplanationProfiles\",
-
-  \                                \"title\": \"Explanation + List\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"navProfilesGeoRegMarkers\",
-
-  \                                \"title\": \"Show All Profiles on Map\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavContributeProfile\",
-
-  \                                \"title\": \"Contribute a Profile\",
-
-  \                                \"type\": \"item\"
-
-  \                              }
-
-  \                            ],
-
-  \                            \"type\": \"dropdown\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"dropdown03\",
-
-  \                            \"title\": \"Feature Lists\",
-
-  \                            \"item\": [
-
-  \                              {
-
-  \                                \"id\": \"li_vicavExplanationFeatures\",
-
-  \                                \"title\": \"Explanation\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"liVicavCrossFeatureQuery\",
-
-  \                                \"title\": \"Cross-examine the VICAV
-  Feature Lists\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"navFeaturesGeoRegMarkers\",
-
-  \                                \"title\": \"Show All Feature Lists on
-  Map\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavContributeFeature\",
-
-  \                                \"title\": \"Contribute a Feature List\",
-
-  \                                \"type\": \"item\"
-
-  \                              }
-
-  \                            ],
-
-  \                            \"type\": \"dropdown\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"dropdown04\",
-
-  \                            \"title\": \"Samples\",
-
-  \                            \"item\": [
-
-  \                              {
-
-  \                                \"id\": \"li_vicavExplanationSamples\",
-
-  \                                \"title\": \"Explanation\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"navSamplesGeoRegMarkers\",
-
-  \                                \"title\": \"Show All Samples on Map\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"liExploreSamples\",
-
-  \                                \"title\": \"Compare Locations\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavContributeSampleText\",
-
-  \                                \"title\": \"Contribute a Sample Text\",
-
-  \                                \"type\": \"item\"
-
-  \                              }
-
-  \                            ],
-
-  \                            \"type\": \"dropdown\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"dropdown05\",
-
-  \                            \"title\": \"Texts\",
-
-  \                            \"item\": [
-
-  \                              {
-
-  \                                \"id\": \"li_vicavExplanationCorpusTexts\",
-
-  \                                \"title\": \"Explanation and Overview\",
-
-  \                                \"type\": \"item\"
-
-  \                              }
-
-  \                            ],
-
-  \                            \"type\": \"dropdown\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"dropdown06\",
-
-  \                            \"title\": \"Dictionaries\",
-
-  \                            \"item\": [
-
-  \                              {
-
-  \                                \"id\": \"navDictGeoRegMarkers\",
-
-  \                                \"title\": \"All Dictionaries in Bibl. on
-  Map\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"navVicavDictMarkers\",
-
-  \                                \"title\": \"All VICAV Dictionaries on
-  Map\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"liVicavCrossDictQuery\",
-
-  \                                \"title\": \"Query the VICAV
-  Dictionaries\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"liVicavDict_Tunis\",
-
-  \                                \"title\": \"TUNICO Dictionary\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"liVicavDict_Damascus\",
-
-  \                                \"title\": \"Damascus Dictionary\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"liVicavDict_Cairo\",
-
-  \                                \"title\": \"Cairo Dictionary\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"liVicavDict_Baghdad\",
-
-  \                                \"title\": \"Baghdad Dictionary\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"liVicavDict_MSA\",
-
-  \                                \"title\": \"MSA Dictionary\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"type\": \"separator\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\":
-  \"li_vicavDictionariesTechnicalities\",
-
-  \                                \"title\": \"Technicalities\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavContributeDictionary\",
-
-  \                                \"title\": \"Contribute a
-  Dictionary\\/Glossary\",
-
-  \                                \"type\": \"item\"
-
-  \                              }
-
-  \                            ],
-
-  \                            \"type\": \"dropdown\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"dropdown07\",
-
-  \                            \"title\": \"Tools & Technology\",
-
-  \                            \"item\": [
-
-  \                              {
-
-  \                                \"id\": \"li_vicavDictionaryEncoding\",
-
-  \                                \"title\": \"Dictionary Encoding\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavVLE\",
-
-  \                                \"title\": \"Dictionary Editor (VLE)\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavArabicTools\",
-
-  \                                \"title\": \"Arabic Research Tools\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\":
-  \"li_vicavOverview_corpora_spoken\",
-
-  \                                \"title\": \"      Corpora (Spoken
-  Varieties)\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavOverview_corpora_msa\",
-
-  \                                \"title\": \"      Corpora (MSA)\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\":
-  \"li_vicavOverview_special_corpora\",
-
-  \                                \"title\": \"      Special Corpora\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\":
-  \"li_vicavOverview_corpora_historical_varieties\",
-
-  \                                \"title\": \"      Corpora (Historical
-  Varieties)\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavOverview_dictionaries\",
-
-  \                                \"title\": \"      Dictionaries\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavOverview_nlp\",
-
-  \                                \"title\": \"      Language Processing
-  Tools\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavOverview_otherStuff\",
-
-  \                                \"title\": \"      Other Websites &
-  Projects\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavLearning\",
-
-  \                                \"title\": \"Learning Materials\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavLearning_tb_damascus\",
-
-  \                                \"title\": \"      Textbook Syrian Arabic
-  (Sound files)\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavLearningSmartphone\",
-
-  \                                \"title\": \"      Vocabularies on
-  Smartphones\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavLearningPrograms\",
-
-  \                                \"title\": \"      Available Programs\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavLearningData\",
-
-  \                                \"title\": \"      Available Data\",
-
-  \                                \"type\": \"item\"
-
-  \                              },
-
-  \                              {
-
-  \                                \"id\": \"li_vicavKeyboards\",
-
-  \                                \"title\": \"Keyboard Layouts\",
-
-  \                                \"type\": \"item\"
-
-  \                              }
-
-  \                            ],
-
-  \                            \"type\": \"dropdown\"
-
-  \                          }
-
-  \                        ],
-
-  \                        \"subnav\": [
-
-  \                          {
-
-  \                            \"id\": \"subNavBiblGeoMarkers\",
-
-  \                            \"class\": \"active\",
-
-  \                            \"title\": \"Bibl. Locations\",
-
-  \                            \"type\": \"item\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"subNavBiblRegMarkers\",
-
-  \                            \"title\": \"Bibl. Regions\",
-
-  \                            \"type\": \"item\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"subNavDictGeoRegMarkers\",
-
-  \                            \"title\": \"Bibl. (Dictionaries)\",
-
-  \                            \"type\": \"item\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"subNavTextbookGeoRegMarkers\",
-
-  \                            \"title\": \"Bibl. (Textbooks)\",
-
-  \                            \"type\": \"item\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"subNavProfilesGeoRegMarkers\",
-
-  \                            \"title\": \"Profiles\",
-
-  \                            \"type\": \"item\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"subNavFeaturesGeoRegMarkers\",
-
-  \                            \"title\": \"Features\",
-
-  \                            \"type\": \"item\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"subNavSamplesGeoRegMarkers\",
-
-  \                            \"title\": \"Samples\",
-
-  \                            \"type\": \"item\"
-
-  \                          },
-
-  \                          {
-
-  \                            \"id\": \"subNavVicavDictMarkers\",
-
-  \                            \"title\": \"VICAV Dictionaries\",
-
-  \                            \"type\": \"item\"
-
-  \                          }
-
-  \                        ]
-
-  \                      }
-
-  \                    }
-
-  \                  }
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: project
-
-  \                  wrapped: false
-
-  \              examples:
-
-  \                project_config_XML_and_rendered_XHTML:
-
-  \                  summary: the project configuration
-
-  \                  value: >
-
-  \                    <project>
-
-  \                      <config>
-
-  \                        <projectConfig xml:space=\"preserve\"
-  id=\"vicav_config_vicav\">
-
-  \                      <title>VICAV3.0 - Vienna Corpus of Arabic
-  Varieties</title>
-
-  \                      <logo><img src=\"images/vicav_logo.svg\"/></logo>
-
-  \                      <frontpage method=\"geo\">
-
-  \                        <param>.*</param>
-
-  \                        <param>geo</param>
-
-  \                        <panel type=\"text\"
-  target=\"li_vicavMission\">MISSION</panel>
-
-  \                        <panel type=\"text\"
-  target=\"li_vicavNews\">NEWS</panel>
-
-  \                      </frontpage>
-
-  \                      <menu>
-
-  \                        <main>
-
-  \                          <dropdown xml:id=\"dropdown00\"
-  title=\"Project\">
-
-  \                            <item xml:id=\"li_vicavMission\">Mission</item>
-
-  \                            <item xml:id=\"li_vicavNews\">News</item>
-
-  \                            <separator/>
-
-  \                            <item xml:id=\"li_vicavTypesOfText\">Types of
-  Text/Data</item>
-
-  \                            <item
-  xml:id=\"li_vicavContributors\">Contributors</item>
-
-  \                            <item
-  xml:id=\"li_vicavLinguistics\">Linguistics</item>
-
-  \                          </dropdown>
-
-  \                        </main>
-
-  \                        <subnav>
-
-  \                          <item xml:id=\"subNavBiblGeoMarkers\"
-  class=\"active\">Bibl. Locations</item>
-
-  \                        </subnav>
-
-  \                      </menu>
-
-  \                    </projectConfig>
-
-  \                      </config>
-
-  \                      <renderedMenu>
-
-  \                        <menu xmlns=\"http://www.w3.org/1999/xhtml\">
-
-  \                          <main>
-
-  \                            <ul class=\"navbar-nav mr-auto\">
-
-  \                              <li class=\"nav-item dropdown\">
-
-  \                                <a class=\"nav-link dropdown-toggle\"
-  data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"
-  id=\"dropdown00\">Project</a>
-
-  \                                <div class=\"dropdown-menu\"
-  aria-labelledby=\"dropdown00\">
-
-  \                                  <a class=\"dropdown-item\"
-  id=\"li_vicavMission\">Mission</a>
-
-  \                                  <a class=\"dropdown-item\"
-  id=\"li_vicavNews\">News</a>
-
-  \                                  <div class=\"dropdown-divider\"/>
-
-  \                                  <a class=\"dropdown-item\"
-  id=\"li_vicavTypesOfText\">Types of Text/Data</a>
-
-  \                                  <a class=\"dropdown-item\"
-  id=\"li_vicavContributors\">Contributors</a>
-
-  \                                  <a class=\"dropdown-item\"
-  id=\"li_vicavLinguistics\">Linguistics</a>
-
-  \                                </div>
-
-  \                              </li>
-
-  \                            </ul>
-
-  \                          </main>
-
-  \                          <subnav xmlns=\"\">
-
-  \                            <span xmlns=\"http://www.w3.org/1999/xhtml\"
-  xml:space=\"preserve\" id=\"subNavBiblGeoMarkers\"><i class=\"fa fa-map\"
-  aria-hidden=\"true\"/> Bibl. Locations</span>
-
-  \                          </subnav>
-
-  \                        </menu>
-
-  \                      </renderedMenu>
-
-  \                    </project>
-
-  \  /text:
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: gets a description text identtified by its tei:div@xml:id
-
-  \      operationId: getText
-
-  \      description: |
-
-  \        By passing the appropriate xml-ID and xslt you can retrieve ready
-  to display html
-
-  \      parameters:
-
-  \        - in: query
-
-  \          name: id
-
-  \          description: the @xml:id of the tei:div xml element
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: xslt
-
-  \          required: false
-
-  \          description: the filename of the xslt transformation (for
-  development purposes only)
-
-  \          schema:
-
-  \            type: string
-
-  \      responses:
-
-  \        '200':
-
-  \          description: the transformed html
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: div
-
-  \                  wrapped: false
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: >
-
-  \                    <div xmlns:tei=\"http://www.tei-c.org/ns/1.0\">
-
-
-  \                    <table class=\"tbHeader\">
-
-  \                    <tr>
-
-  \                    <td>
-
-  \                    <h2>Sample Texts (Explanation)</h2>
-
-  \                    </td>
-
-  \                    <td>{teiLink}</td>
-
-  \                    </tr>
-
-  \                    </table>
-
-
-
-  \                    <p>The sample texts are translations of the same
-
-  \                    <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;sample:msa_sample_01/Modern Standard
-  Arabic&#34;, this)\">source text</a>. They vary slightly with respect to
-  regional
-
-  \                    differences. However, they are homogeneous enough to
-  allow students to
-
-  \                    compare the numerous linguistic phenomena displayed in
-  the texts.</p>
-
-
-
-  \                    <p>Sofar we provide sample texts for six locations:
-
-  \                    <ul>
-
-
-  \                    <li>
-
-  \                    <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;sample:baghdad_sample_01/Baghdad&#34;,
-  this)\">Baghdad</a>
-
-  \                    </li>
-
-
-  \                    <li>
-
-  \                    <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;sample:cairo_sample_01/Cairo&#34;,
-  this)\">Cairo</a>
-
-  \                    </li>
-
-
-  \                    <li>
-
-  \                    <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;sample:damascus_sample_01/Damascus&#34;,
-  this)\">Damascus</a>
-
-  \                    </li>
-
-
-  \                    <li>
-
-  \                    <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;sample:douz_sample_01/Douz&#34;,
-  this)\">Douz</a>
-
-  \                    </li>
-
-
-  \                    <li>
-
-  \                    <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;sample:urfa_sample_01/%C5%9Eanl%C4%B1urfa\
-  &#34;, this)\">Şanlıurfa</a>
-
-  \                    </li>
-
-
-  \                    <li>
-
-  \                    <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;sample:tunis_sample_01/Tunis&#34;,
-  this)\">Tunis</a>
-
-  \                    </li>
-
-  \                    </ul>
-
-  \                    </p>
-
-  \                    </div>
-
-  \        '500':
-
-  \          description: bad input parameter
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
-  \  /profile:
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: gets a langauge profile identified by its TEI@xml:id
-
-  \      operationId: getProfile
-
-  \      description: |
-
-  \        By passing the appropriate xml-ID and xslt you can retrieve ready
-  to display html
-
-  \      parameters:
-
-  \        - in: query
-
-  \          name: id
-
-  \          description: the @xml:id of the TEI xml element
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: coll
-
-  \          description: the id of the collection/database to use (for
-  development purposes only)
-
-  \          required: false
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: xslt
-
-  \          required: false
-
-  \          description: the filename of the xslt transformation (for
-  development purposes only)
-
-  \          schema:
-
-  \            type: string
-
-  \      responses:
-
-  \        '200':
-
-  \          description: the transformed html
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: >
-
-  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\"
-  xmlns:tei=\"http://www.tei-c.org/ns/1.0\">
-
-  \                    <table class=\"tbHeader\">
-
-  \                    <tr>
-
-  \                    <td>
-
-  \                    <h2>Skoura</h2>
-
-  \                    </td>
-
-  \                    <td class=\"tdTeiLink\">{teiLink}</td>
-
-  \                    </tr>
-
-  \                    </table>
-
-  \                    <div class=\"profileHeader\">
-
-  \                    <div class=\"dvImgProfile\"><img
-  src=\"images/skoura_sp_2012.jpg\"><div class=\"imgCaption\">Courtesy of
-  Stephan Procházka, 2012</div>
-
-  \                    </div>
-
-  \                    <table class=\"tbProfile\">
-
-  \                    <tr>
-
-  \                    <td class=\"tdHead\">MSA Name</td>
-
-  \                    <td class=\"tdProfileTableRight\">سكورة</td>
-
-  \                    </tr>
-
-  \                    <tr>
-
-  \                    <td class=\"tdHead\">MSA Name (trans.)</td>
-
-  \                    <td class=\"tdProfileTableRight\">Sakūra Skūra</td>
-
-  \                    </tr>
-
-  \                    <tr>
-
-  \                    <td class=\"tdHead\">Geo location</td>
-
-  \                    <td class=\"tdProfileTableRight\"><i>
-
-  \                    31°03'N 06°33'W
-
-  \                    Morocco
-
-  \                    </i></td>
-
-  \                    </tr>
-
-  \                    <tr>
-
-  \                    <td class=\"tdHead\">Contributed by</td>
-
-  \                    <td class=\"tdProfileTableRight\"><i>Aleksandra
-  Ercegovčević</i></td>
-
-  \                    </tr>
-
-  \                    </table>
-
-  \                    </div>
-
-  \                    <div class=\"h3ProfileTypology\">Typology</div>
-
-  \                    <table class=\"tbProfile\">
-
-  \                    <tr>
-
-  \                    <td colspan=\"2\" class=\"tdProfileTableRight\">West
-  (Maghreb) › Morocco › Central type</td>
-
-  \                    </tr>
-
-  \                    <tr>
-
-  \                    <td colspan=\"2\"
-  class=\"tdProfileTableRight\">Hilalian-type sedentary rural dialect with
-  strong influence of Berber</td>
-
-  \                    </tr>
-
-  \                    </table>
-
-  \                    <div class=\"h3Profile\">General</div>
-
-
-  \                    <div class=\"pNorm\">Skūra is an Arabic enclave in the
-  Berber-speaking area south of the High Atlas. Many
-
-  \                    of the 15,000 inhabitants are bilingual. They live
-  mainly on agriculture and stock
-
-  \                    breeding.</div>
-
-
-  \                    <div class=\"h3Profile\">Research History</div>
-
-
-  \                    <div class=\"pNorm\">All available data on the dialect
-  of Skūra is from the work of Jorge Aguadé and Mohammad
-
-  \                    Elyaâcoubi. <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;zotid:8SISG2GK&#34;)\">Aguadé 1994</a> is
-  a brief study on the formation of the reflexive-passive forms of the verb. <a
-  class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;zotid:E3T3HBCD&#34;)\">Aguadé and
-  Elyaacoubi 1995</a> is a monograph on the dialect with chapters on phonology,
-  nominal and verbal morphology,
-
-  \                    and verb paradigms. <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;zotid:I3FIKENT&#34;)\">Aguadé et al.
-  1996</a> deals with the irrigation system in the oasis of Skūra, and the
-  technical terminology
-
-  \                    concerning irrigation in the dialect of Skūra.
-  Elyaâcoubi 1998 treats the topic of
-
-  \                    the classification of south Moroccan Arabic dialects on
-  the example of Skūra, where
-
-  \                    a three page-grammatical sketch of the dialect is also
-  provided.</div>
-
-
-  \                    <div class=\"h3Profile\">Dictionaries</div>
-
-
-  \                    <div class=\"pNorm\"><a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;zotid:I3FIKENT&#34;)\">Aguadé et al.
-  1996</a> includes a 2-page glossary of terminology related to the irrigation
-  system (<i>xiṭṭāra</i>).</div>
-
-
-  \                    <div class=\"h3Profile\">Bibliography</div>
-
-
-  \                    <div class=\"pNorm\">To view publications on this
-  variety click <a class=\"aVicText\"
-  href=\"javascript:getDBSnippet(&#34;bibl:geo:Skoura&#34;)\">here</a>.</div>
-
-  \                    <br><br><br></div>
-
-  \        '500':
-
-  \          description: bad input parameter
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
-  \  /explore_samples:
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: gets a specific html transformed via a specified xslt
-
-  \      operationId: getExploreSamples
-
-  \      description: |
-
-  \        By passing the appropriate xml-ID and xslt you can retrieve ready
-  to display html
-
-  \      parameters:
-
-  \        - in: query
-
-  \          name: type
-
-  \          description: the type of query?
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: word
-
-  \          description: the word to search for?
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: xslt
-
-  \          required: false
-
-  \          description: the filename of the xslt transformation (for
-  development purposes only)
-
-  \          schema:
-
-  \            type: string
-
-  \      responses:
-
-  \        '200':
-
-  \          description: the transformed html
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: div
-
-  \                  wrapped: false
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<div xmlns=\"http://www.w3.org/1999/xhtml\"
-  xmlns:tei=\"http://www.tei-c.org/ns/1.0\"><div
-  class=\"explore-samples\"><table class=\"tbHeader\"><tr><td><h2
-  xml:space=\"preserve\">Compare samples</h2></td><td class=\"tdPrintLink\"><a
-  href=\"#\" data-print=\"true\"
-  class=\"aTEIButton\">Print</a></td></tr></table><div
-  class=\"explore-samples-summary\"><h4>Summary</h4><table><tr><th>unknown</th>\
-  <td>1</td></tr></table></div><h3>3</h3><h4>unknown</h4><p
-  xml:space=\"preserve\">1 sentences found.</p><table
-  class=\"tbFeatures\"><tr><td class=\"tdFeaturesHeadRight\"><small
-  xml:space=\"preserve\">%as</small></td><td class=\"tdFeaturesRightTarget\"><a
-  class=\"show-sentence\" title=\"Show full sample text\" href=\"#\"
-  data-sampletext=\"douz_sample_01\"><i class=\"fa fa-eye\"
-  aria-hidden=\"true\"><span/></i></a><span
-  xmlns:acdh=\"http://acdh.oeaw.ac.at\" class=\"spSentence\"
-  xml:space=\"preserve\"><span class=\"sample-text-tooltip\" data-html=\"true\"
-  data-toggle=\"tooltip\" data-placement=\"top\" title=\"Tomaten nahm ich keine,
-  weil sie sehr teuer&#xA;                     waren.\"><i class=\"fa
-  fa-commenting-o\" aria-hidden=\"true\"><span/></i></span> <a
-  class=\"word-search\" href=\"#\" data-wordform=\"mā\"
-  data-type=\"sample\"><span data-html=\"true\" data-placement=\"top\"
-  class=\"w\">mā</span></a><a class=\"word-search\" href=\"#\"
-  data-wordform=\"-\" data-type=\"sample\"><span data-html=\"true\"
-  data-placement=\"top\" class=\"w\">-</span></a><a class=\"word-search\"
-  href=\"#\" data-wordform=\"šrīt\" data-type=\"sample\"><span
-  data-html=\"true\" data-placement=\"top\" class=\"w
-  highlight\">šrīt</span></a><a class=\"word-search\" href=\"#\"
-  data-wordform=\"-\" data-type=\"sample\"><span data-html=\"true\"
-  data-placement=\"top\" class=\"w\">-</span></a><a class=\"word-search\"
-  href=\"#\" data-wordform=\"ǝš\" data-type=\"sample\"><span data-html=\"true\"
-  data-placement=\"top\" class=\"w\">ǝš</span></a> <a class=\"word-search\"
-  href=\"#\" data-wordform=\"iṭ\" data-type=\"sample\"><span data-html=\"true\"
-  data-placement=\"top\" class=\"w\">iṭ</span></a><a class=\"word-search\"
-  href=\"#\" data-wordform=\"-\" data-type=\"sample\"><span data-html=\"true\"
-  data-placement=\"top\" class=\"w\">-</span></a><a class=\"word-search\"
-  href=\"#\" data-wordform=\"ṭamāṭim\" data-type=\"sample\"><span
-  data-html=\"true\" data-placement=\"top\" class=\"w\">ṭamāṭim</span></a> <a
-  class=\"word-search\" href=\"#\" data-wordform=\"ʿal\"
-  data-type=\"sample\"><span data-html=\"true\" data-placement=\"top\"
-  class=\"w\">ʿal</span></a><a class=\"word-search\" href=\"#\"
-  data-wordform=\"-\" data-type=\"sample\"><span data-html=\"true\"
-  data-placement=\"top\" class=\"w\">-</span></a><a class=\"word-search\"
-  href=\"#\" data-wordform=\"xāṭir\" data-type=\"sample\"><span
-  data-html=\"true\" data-placement=\"top\" class=\"w\">xāṭir</span></a> <a
-  class=\"word-search\" href=\"#\" data-wordform=\"kānat\"
-  data-type=\"sample\"><span data-html=\"true\" data-placement=\"top\"
-  class=\"w\">kānat</span></a> <a class=\"word-search\" href=\"#\"
-  data-wordform=\"ġālya\" data-type=\"sample\"><span data-html=\"true\"
-  data-placement=\"top\" class=\"w\">ġālya</span></a><a class=\"word-search\"
-  href=\"#\" data-wordform=\".\" data-type=\"sample\"><span data-html=\"true\"
-  data-placement=\"top\" class=\"w\">.</span></a>
-  </span></td></tr></table></div></div>'
-
-  \        '500':
-
-  \          description: bad input parameter
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
-  \  /biblio_tei:
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: gets a specific html transformed via a specified xslt
-
-  \      operationId: getBiblioTei
-
-  \      description: |
-
-  \        By passing a well formed query and xslt you can retrieve ready to
-  display html
-
-  \      parameters:
-
-  \        - in: query
-
-  \          name: query
-
-  \          description: the query
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: xslt
-
-  \          required: false
-
-  \          description: the filename of the xslt transformation (for
-  development purposes only)
-
-  \          schema:
-
-  \            type: string
-
-  \      responses:
-
-  \        '200':
-
-  \          description: the transformed html
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: div
-
-  \                  wrapped: false
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<div
-  xmlns:tei=\"http://www.tei-c.org/ns/1.0\"><div class=\"dvStats\">Query:  <span
-  class=\"spQueryText\">{query}</span></div><div class=\"dvStats\">1
-  record </div><div class=\"dvBibBook\"><div
-  class=\"dvAuthor\"><b>Hagenbucher,<span xml:space=\"preserve\">
-  </span>F.</b></div><div class=\"dvBiblBlock\"><img class=\"imgBiblItem\"
-  src=\"images/book_001.jpg\"/>Les arabes dits “suwa” du Nord-Cameroun.<span
-  xml:space=\"preserve\"> </span>Yaounde.<span xml:space=\"preserve\">
-  </span>ORSTOM.<span xml:space=\"preserve\"> </span>1973.</div></div></div>'
-
-  \        '500':
-
-  \          description: bad input parameter
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
-  \  /bibl_markers_tei:
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: gets a geo marker information\ 
-
-  \      operationId: getMarkers
-
-  \      description: |
-
-  \        Retrieve geo data information from the bibliography for displaying
-  coordinates on a map.
-
-  \      parameters:
-
-  \        - in: query
-
-  \          name: query
-
-  \          description: |
-
-  \            A BaseX Full-Text search query in in vicav-biblio
-  tei:biblstruct with wildcards enabled.
-
-  \            See: https://docs.basex.org/wiki/Full-Text#Match_Options
-
-  \            using wildcards using diacritics sensitive
-
-  \            Uses prefixes to limit the full text search to certein
-  elements.
-
-  \            * date: -> tei:date
-
-  \            * title: -> tei:title
-
-  \            * pubPlace: -> tei:pubPlace
-
-  \            * author: -> tei:author/tei:surname
-
-  \            * geo:, geo_reg:, reg:, diaGroup: ->
-  tei:note[@type=\"tag\"]/tei:name
-
-  \            * vt:, prj: -> tei:note[@type=\"tag\"]
-
-  \           \ 
-
-  \            Without a prefix any text in vicav-biblio tei:biblstruct is
-  searched.
-
-  \           \ 
-
-  \            More than one query is possible by separating with ' '/+.
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: scope
-
-  \          required: true
-
-  \          description: |
-
-  \            Filters based on a set of tei:name/@types being present in a
-  tei:note[tei:geo]          \ 
-
-  \            * geo
-
-  \            * diaGroup
-
-  \            * reg
-
-  \            * geo_reg: any of the above
-
-  \          schema:
-
-  \            type: string           \ 
-
-  \            enum:
-
-  \            - geo_reg
-
-  \            - geo
-
-  \            - reg
-
-  \            - diaGroup
-
-  \      responses:
-
-  \        '200':
-
-  \          description: a list of geo markers
-
-  \          content:
-
-  \            application/json:
-
-  \              schema:
-
-  \                type: array
-
-  \                items:
-
-  \                  type: object
-
-  \                  schema:
-
-  \                    $ref: '#/components/schemas/Feature'
-
-  \              examples:
-
-  \                geoJSON_features_Ma_geo_reg:
-
-  \                  summary: 'query: Ma.*. scope: geo_reg, shorted'
-
-  \                  value: [
-
-  \                          {
-
-  \                            \"type\": \"Feature\",
-
-  \                            \"geometry\": {
-
-  \                              \"type\": \"Point\",
-
-  \                              \"coordinates\": [
-
-  \                                \"35.578333\",
-
-  \                                \"-5.368056\"
-
-  \                              ]
-
-  \                            },
-
-  \                            \"properties\": {
-
-  \                              \"type\": \"geo\",
-
-  \                              \"name\": \"Tétouan\",
-
-  \                              \"hitCount\": \"16\"
-
-  \                            }
-
-  \                          },
-
-  \                          {
-
-  \                            \"type\": \"Feature\",
-
-  \                            \"geometry\": {
-
-  \                              \"type\": \"Point\",
-
-  \                              \"coordinates\": [
-
-  \                                \"32.000000\",
-
-  \                                \"-6.000000\"
-
-  \                              ]
-
-  \                            },
-
-  \                            \"properties\": {
-
-  \                              \"type\": \"reg\",
-
-  \                              \"name\": \"Morocco\",
-
-  \                              \"hitCount\": \"1157\"
-
-  \                            }
-
-  \                          }
-
-  \                        ]
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: rs
-
-  \                  wrapped: false
-
-  \                items:
-
-  \                  type: object
-
-  \              examples:
-
-  \                xml:
-
-  \                  summary: a list of geo markers
-
-  \                  value: >
-
-  \                    <rs type=\"60\">
-
-  \                      <r type=\"geo\">
-
-  \                        <geo>35.578333 -5.368056</geo>
-
-  \                        <alt>Tétouan</alt>
-
-  \                        <freq>1</freq>
-
-  \                      </r>
-
-  \                      <r type=\"reg\">
-
-  \                        <geo>32.000000 -6.000000</geo>
-
-  \                        <alt>Morocco</alt>
-
-  \                        <freq>44</freq>
-
-  \                      </r>
-
-  \                      <r type=\"reg\">
-
-  \                        <geo>34.000000 9.000000</geo>
-
-  \                        <alt>Tunisia</alt>
-
-  \                        <freq>4</freq>
-
-  \                      </r>
-
-  \                    </rs>
-
-  \        '500':
-
-  \          description: bad input parameter
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
-  \  /{name}_markers:
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: gets a specific xml
-
-  \      operationId: sampleMarkers
-
-  \      description: |
-
-  \        I have no idea
-
-  \      parameters:
-
-  \        - in: path
-
-  \          name: name
-
-  \          description: a reference to a predefined query?
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \      responses:
-
-  \        '200':
-
-  \          description: an xml result list
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: rs
-
-  \                  wrapped: false
-
-  \                items:
-
-  \                  type: object
-
-  \              examples:
-
-  \                xml:
-
-  \                  summary: A list of geo markers
-
-  \                  value: >
-
-  \                    <rs>
-
-  \                      <r type=\"geo\" xml:id=\"baghdad_sample_01\">
-
-  \                        <loc>33°20'N 44°24'E</loc>
-
-  \                        <locName>
-
-  \                          <name xmlns=\"http://www.tei-c.org/ns/1.0\"
-  xml:lang=\"eng\">Baghdad</name>
-
-  \                        </locName>
-
-  \                        <alt>
-
-  \                          <name xmlns=\"http://www.tei-c.org/ns/1.0\"
-  xml:lang=\"eng\">Baghdad</name>
-
-  \                        </alt>
-
-  \                        <freq>1</freq>
-
-  \                      </r>
-
-  \                      <r type=\"geo\" xml:id=\"cairo_sample_01\">
-
-  \                        <loc>30°03'N 31°14'E</loc>
-
-  \                        <locName>
-
-  \                          <name xmlns=\"http://www.tei-c.org/ns/1.0\"
-  xml:lang=\"eng\">Cairo</name>
-
-  \                        </locName>
-
-  \                        <alt>
-
-  \                          <name xmlns=\"http://www.tei-c.org/ns/1.0\"
-  xml:lang=\"eng\">Cairo</name>
-
-  \                        </alt>
-
-  \                        <freq>1</freq>
-
-  \                      </r>
-
-  \                    </rs>
-
-  \        '404':
-
-  \          description: not found
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
-  \  /dict_api:
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: gets a specific html transformed via a specified xslt
-
-  \      operationId: getDictApi
-
-  \      description: |
-
-  \        By passing a well formed query and xslt you can retrieve ready to
-  display html
-
-  \      parameters:
-
-  \        - in: query
-
-  \          name: query
-
-  \          description: the query
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: dict
-
-  \          description: the dict id?
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: xslt
-
-  \          required: false
-
-  \          description: the filename of the xslt transformation (for
-  development purposes only)
-
-  \          schema:
-
-  \            type: string
-
-  \      responses:
-
-  \        '200':
-
-  \          description: the transformed html
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: div
-
-  \                  wrapped: false
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: >
-
-  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\"
-  xmlns:tei=\"http://www.tei-c.org/ns/1.0\">
-
-  \                    <div class=\"dvStats\" id=\"dvStats\">0&nbsp;hits</div>
-
-  \                    </div>
-
-  \        '500':
-
-  \          description: bad input parameter
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
-  \  /dict_index:
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: gets a specific html transformed via a specified xslt
-
-  \      operationId: getDictIndex
-
-  \      description: |
-
-  \        By passing a well formed query you can retrieve ready to display
-  html
-
-  \      parameters:
-
-  \        - in: query
-
-  \          name: dict
-
-  \          description: the dict id?
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: ind
-
-  \          required: true
-
-  \          description: I have no idea
-
-  \          schema:
-
-  \            type: string
-
-  \            enum:
-
-  \              - any
-
-  \              - lem
-
-  \              - infl
-
-  \              - en
-
-  \              - de
-
-  \              - fr
-
-  \              - pos
-
-  \              - root
-
-  \              - subc
-
-  \              - etymSrc
-
-  \              - etymLang
-
-  \        - in: query
-
-  \          name: str
-
-  \          required: true
-
-  \          description: the query string?
-
-  \          schema:
-
-  \            type: string
-
-  \      responses:
-
-  \        '200':
-
-  \          description: the transformed html
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: div
-
-  \                  wrapped: false
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: >
-
-  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\">
-
-  \                    <option class=\"opWordList_de\">'[abstauben]</option>
-
-  \                    <option class=\"opWordList_de\">[Abbilden]</option>
-
-  \                    <option class=\"opWordList_de\">[Abdruck]</option>
-
-  \                    <option class=\"opWordList_de\">[Abend]</option>
-
-  \                    <option class=\"opWordList_de\">[Abend]-</option>
-
-  \                    <option class=\"opWordList_de\">[Abendessen]</option>
-
-  \                    <option class=\"opWordList_de\">[Abendgebet]</option>
-
-  \                    <option class=\"opWordList_de\">[Abenteuer]</option>
-
-  \                    <option class=\"opWordList_de\">[Abfall]</option>
-
-  \                    <option class=\"opWordList_de\">[Abfallhaufen]</option>
-
-  \                    <option class=\"opWordList_de\">[Abflussloch]</option>
-
-  \                    <option class=\"opWordList_de\">[Abflussrinne]</option>
-
-  \                    <option class=\"opWordList_de\">[Abflussrohr]</option>
-
-  \                    <option class=\"opWordList_de\">[Abflußkanal]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[Abgeordnetenhaus]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[Abgeordnetenkammer]</option>
-
-  \                    <option class=\"opWordList_de\">[Abgeordneter]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[Abgeschiedenheit]</option>
-
-  \                    <option class=\"opWordList_de\">[Abitur]</option>
-
-  \                    <option class=\"opWordList_de\">[Abkürzung]</option>
-
-  \                    <option class=\"opWordList_de\">[Ablenkung]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[Ablflussrinne]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[Ablutionskännchen]</option>
-
-  \                    <option class=\"opWordList_de\">[Abmachung]</option>
-
-  \                    <option class=\"opWordList_de\">[Abort]</option>
-
-  \                    <option class=\"opWordList_de\">[Abortgrube]</option>
-
-  \                    <option class=\"opWordList_de\">[Absatz]</option>
-
-  \                    <option class=\"opWordList_de\">[Abscheu]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[Abscheulichkeit]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[Abschiedsgruß]</option>
-
-  \                    <option class=\"opWordList_de\">[Abschneiden]</option>
-
-  \                    <option class=\"opWordList_de\">[Abschnitt]</option>
-
-  \                    <option class=\"opWordList_de\">[Absender]</option>
-
-  \                    <option class=\"opWordList_de\">[Absicht]</option>
-
-  \                    <option class=\"opWordList_de\">[Abstand]</option>
-
-  \                    <option class=\"opWordList_de\">[Abstellbrett]</option>
-
-  \                    <option class=\"opWordList_de\">[Abstellraum]</option>
-
-  \                    <option class=\"opWordList_de\">[Abstieg]</option>
-
-  \                    <option class=\"opWordList_de\">[Abszess]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[Abteilungsleiter]</option>
-
-  \                    <option class=\"opWordList_de\">[Abtritt]</option>
-
-  \                    <option class=\"opWordList_de\">[Abwesenheit]</option>
-
-  \                    <option class=\"opWordList_de\">[Abwickeln]</option>
-
-  \                    <option class=\"opWordList_de\">[Abzweigung]</option>
-
-  \                    <option class=\"opWordList_de\">[abbiegen]</option>
-
-  \                    <option class=\"opWordList_de\">[abbrechen]</option>
-
-  \                    <option class=\"opWordList_de\">[abdecken]</option>
-
-  \                    <option class=\"opWordList_de\">[abendlich]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[abendländisch]</option>
-
-  \                    <option class=\"opWordList_de\">[aber]</option>
-
-  \                    <option class=\"opWordList_de\">[abfahren]</option>
-
-  \                    <option class=\"opWordList_de\">[abfangen]</option>
-
-  \                    <option class=\"opWordList_de\">[abgeben]</option>
-
-  \                    <option class=\"opWordList_de\">[abgebildet]</option>
-
-  \                    <option class=\"opWordList_de\">[abgenutzt]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[abgeschrieben]</option>
-
-  \                    <option class=\"opWordList_de\">[abgeschält]</option>
-
-  \                    <option class=\"opWordList_de\">[abgestempelt]</option>
-
-  \                    <option
-  class=\"opWordList_de\">[abgewirtschaftet]</option>
-
-  \                    <option class=\"opWordList_de\">[abhauen]</option>
-
-  \                    <option class=\"opWordList_de\">[abheben]</option>
-
-  \                    <option class=\"opWordList_de\">[abhäuten]</option>
-
-  \                    <option class=\"opWordList_de\">[ablehnen]</option>
-
-  \                    <option class=\"opWordList_de\">[abliefern]</option>
-
-  \                    <option class=\"opWordList_de\">[abmagern]</option>
-
-  \                    <option class=\"opWordList_de\">[abnehmen]</option>
-
-  \                    <option class=\"opWordList_de\">[abnormal]</option>
-
-  \                    <option class=\"opWordList_de\">[abreisen]</option>
-
-  \                    <option class=\"opWordList_de\">[abreißen]</option>
-
-  \                    <option class=\"opWordList_de\">[abschaben]</option>
-
-  \                    <option class=\"opWordList_de\">[abscheulich]</option>
-
-  \                    <option class=\"opWordList_de\">[abschlachten]</option>
-
-  \                    <option class=\"opWordList_de\">[abschneiden]</option>
-
-  \                    <option class=\"opWordList_de\">[abschreiben]</option>
-
-  \                    <option class=\"opWordList_de\">[abseihen]</option>
-
-  \                    <option class=\"opWordList_de\">[absengen]</option>
-
-  \                    <option class=\"opWordList_de\">[absichtlich]</option>
-
-  \                    <option class=\"opWordList_de\">[absteigen]</option>
-
-  \                    <option class=\"opWordList_de\">[abstoßen]</option>
-
-  \                    <option class=\"opWordList_de\">[abstreiten]</option>
-
-  \                    <option class=\"opWordList_de\">[abwaschen]</option>
-
-  \                    <option class=\"opWordList_de\">[abwesend]</option>
-
-  \                    <option class=\"opWordList_de\">[abwischen]</option>
-
-  \                    <option class=\"opWordList_de\">[abziehen]</option>
-
-  \                    <option class=\"opWordList_en\">[abdomen]</option>
-
-  \                    <option class=\"opWordList_en\">[abhorrence]</option>
-
-  \                    <option class=\"opWordList_en\">[ability]</option>
-
-  \                    <option class=\"opWordList_en\">[ablution]</option>
-
-  \                    <option class=\"opWordList_en\">[about]</option>
-
-  \                    <option class=\"opWordList_en\">[above]</option>
-
-  \                    <option class=\"opWordList_en\">[abroad]</option>
-
-  \                    <option class=\"opWordList_en\">[abscess]</option>
-
-  \                    <option class=\"opWordList_en\">[absence]</option>
-
-  \                    <option class=\"opWordList_en\">[absent]</option>
-
-  \                    <option class=\"opWordList_en\">[absolutely]</option>
-
-  \                    <option class=\"opWordList_en\">[abundantly]</option>
-
-  \                    <option class=\"opWordList_fr\">[abaissement]</option>
-
-  \                    <option class=\"opWordList_fr\">[abaisser]</option>
-
-  \                    <option class=\"opWordList_fr\">[abattage]</option>
-
-  \                    <option class=\"opWordList_fr\">[abattement]</option>
-
-  \                    <option class=\"opWordList_fr\">[abattre]</option>
-
-  \                    <option class=\"opWordList_fr\">[abattu]</option>
-
-  \                    <option class=\"opWordList_fr\">[abdomen]</option>
-
-  \                    <option class=\"opWordList_fr\">[abeilles]</option>
-
-  \                    <option class=\"opWordList_fr\">[ablution]</option>
-
-  \                    <option class=\"opWordList_fr\">[aboiement]</option>
-
-  \                    <option class=\"opWordList_fr\">[abonder]</option>
-
-  \                    <option class=\"opWordList_fr\">[aboyer]</option>
-
-  \                    <option class=\"opWordList_fr\">[abreuver]</option>
-
-  \                    <option class=\"opWordList_fr\">[abricots]</option>
-
-  \                    <option class=\"opWordList_fr\">[absence]</option>
-
-  \                    <option class=\"opWordList_fr\">[absent]</option>
-
-  \                    <option class=\"opWordList_fr\">[absolument]</option>
-
-  \                    <option class=\"opWordList_fr\">[absolutment]</option>
-
-  \                    <option class=\"opWordList_fr\">[abuser]</option>
-
-  \                    <option class=\"opWordList_fr\">[abîmé]</option>
-
-  \                    <option class=\"opWordList_de\">([Ab])hang</option>
-
-  \                    <option class=\"opWordList_de\">([Ab])wiegen</option>
-
-  \                    <option class=\"opWordList_de\">(Geld)
-  [abheben]</option>
-
-  \                    <option class=\"opWordList_de\">(Staub)
-  [abklopfen]</option>
-
-  \                    <option
-  class=\"opWordList_de\">(Unter-)[Abteilung]</option>
-
-  \                    <option class=\"opWordList_de\">(Zigarette)
-  [abaschen]</option>
-
-  \                    <option class=\"opWordList_de\">([ab])stützen</option>
-
-  \                    <option class=\"opWordList_de\">([ab])wägen</option>
-
-  \                    <option class=\"opWordList_de\">([ab]-)lecken</option>
-
-  \                    <option class=\"opWordList_de\">(edle)
-  [Abstammung]</option>
-
-  \                    <option class=\"opWordList_de\">(früher)
-  [Abend]</option>
-
-  \                    <option class=\"opWordList_de\">(gute)
-  [Absicht]</option>
-
-  \                    <option class=\"opWordList_de\">(stark)
-  [abnehmen]</option>
-
-  \                    <option class=\"opWordList_de\">[Abscheu]
-  erregen</option>
-
-  \                    <option class=\"opWordList_de\">[Abschied]
-  nehmen</option>
-
-  \                    <option class=\"opWordList_de\">Guten [Abend]!</option>
-
-  \                    <option class=\"opWordList_de\">Hau [ab]!</option>
-
-  \                    <option class=\"opWordList_de\">Luft
-  [ablassen]</option>
-
-  \                    <option class=\"opWordList_de\">Stimme
-  [abgeben]</option>
-
-  \                    <option class=\"opWordList_de\">[abendliche]
-  Feier</option>
-
-  \                    <option class=\"opWordList_de\">[aber]...nicht</option>
-
-  \                    <option class=\"opWordList_de\">[abgehen]
-  (Zug)</option>
-
-  \                    <option class=\"opWordList_de\">[abgenützt]
-  werden</option>
-
-  \                    <option class=\"opWordList_de\">[abgerissenes]
-  Kleidungsstück</option>
-
-  \                    <option class=\"opWordList_de\">[abgeschnittene]
-  Locke</option>
-
-  \                    <option class=\"opWordList_de\">[abgesehen]
-  davon</option>
-
-  \                    <option class=\"opWordList_de\">[abgesehen]
-  von</option>
-
-  \                    <option class=\"opWordList_de\">[abheben]
-  (Geld)</option>
-
-  \                    <option class=\"opWordList_de\">[abhängen] von</option>
-
-  \                    <option class=\"opWordList_de\">[abhängig] von</option>
-
-  \                    <option class=\"opWordList_de\">[abhören]
-  (Patient)</option>
-
-  \                    <option class=\"opWordList_de\">[ablassen] von</option>
-
-  \                    <option class=\"opWordList_de\">[abschleppen]
-  (Auto)</option>
-
-  \                    <option class=\"opWordList_de\">[abspülen]
-  (Geschirr)</option>
-
-  \                    <option class=\"opWordList_de\">[abstürzen]
-  (Computer</option>
-
-  \                    <option class=\"opWordList_de\">[abtrünniger]
-  Muslim</option>
-
-  \                    <option class=\"opWordList_de\">[abwesend]
-  sein</option>
-
-  \                    <option class=\"opWordList_de\">[abzielen] auf</option>
-
-  \                    <option class=\"opWordList_de\">en [abondance]</option>
-
-  \                    <option class=\"opWordList_de\">etw.
-  [abbrechen]</option>
-
-  \                    <option class=\"opWordList_de\">etw.
-  [abkratzen]</option>
-
-  \                    <option class=\"opWordList_de\">gegen [Abend]</option>
-
-  \                    <option class=\"opWordList_de\">heute [Abend]</option>
-
-  \                    <option class=\"opWordList_de\">langsam
-  [abfließen]</option>
-
-  \                    <option class=\"opWordList_de\">mit [Absicht]</option>
-
-  \                    <option class=\"opWordList_de\">nun [aber]</option>
-
-  \                    <option class=\"opWordList_de\">sich [abmühen]</option>
-
-  \                    <option class=\"opWordList_de\">vorgestern
-  [Abend]</option>
-
-  \                    <option class=\"opWordList_en\">[about] what</option>
-
-  \                    <option class=\"opWordList_en\">[absolutely]
-  nothing</option>
-
-  \                    <option class=\"opWordList_en\">caring [about]</option>
-
-  \                    <option class=\"opWordList_en\">from [above]</option>
-
-  \                    <option class=\"opWordList_en\">from [abroad]</option>
-
-  \                    <option class=\"opWordList_en\">to [abandon]</option>
-
-  \                    <option class=\"opWordList_en\">to [abound]</option>
-
-  \                    <option class=\"opWordList_en\">to [abuse]</option>
-
-  \                    <option class=\"opWordList_fr\">[aborder] qc.</option>
-
-  \                    <option class=\"opWordList_fr\">[abîmer] qc.</option>
-
-  \                    <option class=\"opWordList_fr\">d'[abord]</option>
-
-  \                    <option class=\"opWordList_fr\">devenir
-  [abondant]</option>
-
-  \                    <option class=\"opWordList_fr\">d’[abord]</option>
-
-  \                    <option class=\"opWordList_fr\">règle
-  [absolue]</option>
-
-  \                    <option class=\"opWordList_fr\">s’[abîmer]</option>
-
-  \                    <option class=\"opWordList_fr\">être
-  [abandonné]</option>
-
-  \                    <option class=\"opWordList_fr\">être [absent]</option>
-
-  \                    <option class=\"opWordList_de\">([ab])wiegen
-  (Gewicht)</option>
-
-  \                    <option class=\"opWordList_de\">(die Schule/ das
-  Studium) [abschließen]/[absolvieren]</option>
-
-  \                    <option class=\"opWordList_de\">[Ablegen] von
-  Gegenständen</option>
-
-  \                    <option class=\"opWordList_de\">[Abreibung] (mit
-  Seife)</option>
-
-  \                    <option class=\"opWordList_de\">[Abweichung] (vom
-  Rechten)</option>
-
-  \                    <option class=\"opWordList_de\">[abgerissenes]
-  zerlumptes Kleidungsstück</option>
-
-  \                    <option class=\"opWordList_de\">[abgewickelt] werden
-  (Geschäft)</option>
-
-  \                    <option class=\"opWordList_de\">[abhängig] sein
-  von</option>
-
-  \                    <option class=\"opWordList_de\">[abnehmen] (den
-  Telefonhörer)</option>
-
-  \                    <option class=\"opWordList_de\">an jenem
-  [Abend]</option>
-
-  \                    <option class=\"opWordList_de\">austreten (auf
-  [Abort])</option>
-
-  \                    <option class=\"opWordList_de\">das Fell
-  [abziehen]</option>
-
-  \                    <option class=\"opWordList_de\">die [Absicht]
-  habend...</option>
-
-  \                    <option class=\"opWordList_de\">eine [Abteilung]
-  Soldaten</option>
-
-  \                    <option class=\"opWordList_de\">mit der
-  [Absicht]</option>
-
-  \                    <option class=\"opWordList_de\">sich (gegenseitig)
-  [abküssen]</option>
-
-  \                    <option class=\"opWordList_de\">sich [abwenden]
-  von</option>
-
-  \                    <option class=\"opWordList_de\">sich [abzeichnend]
-  (Konturen)</option>
-
-  \                    <option class=\"opWordList_de\">von ihm
-  [abfallen]</option>
-
-  \                    <option class=\"opWordList_de\">zu [Abend]
-  essen</option>
-
-  \                    <option class=\"opWordList_de\">zu [Abend]
-  speisen</option>
-
-  \                    <option class=\"opWordList_en\">hanging
-  [about]/around</option>
-
-  \                    <option class=\"opWordList_en\">to [abandon]
-  sth.</option>
-
-  \                    <option class=\"opWordList_en\">to [abate]
-  (price)</option>
-
-  \                    <option class=\"opWordList_en\">to be
-  [abandoned]</option>
-
-  \                    <option class=\"opWordList_en\">to be [able]</option>
-
-  \                    <option class=\"opWordList_en\">to be [absent]</option>
-
-  \                    <option class=\"opWordList_en\">to complain
-  [about]</option>
-
-  \                    <option class=\"opWordList_en\">to laze
-  ([about])</option>
-
-  \                    <option class=\"opWordList_en\">to reflect
-  ([about])</option>
-
-  \                    <option class=\"opWordList_en\">to strut
-  [about]</option>
-
-  \                    <option class=\"opWordList_en\">to think
-  ([about])</option>
-
-  \                    <option class=\"opWordList_en\">to worry
-  [about]</option>
-
-  \                    <option class=\"opWordList_en\">wandering
-  [about]/around</option>
-
-  \                    <option class=\"opWordList_fr\">[abandonner]
-  qn./qc.</option>
-
-  \                    <option class=\"opWordList_fr\">[abri] de
-  fortune</option>
-
-  \                    <option class=\"opWordList_fr\">ne... [absolument]
-  personne</option>
-
-  \                    <option class=\"opWordList_fr\">s'[abattre]
-  sur</option>
-
-  \                    <option class=\"opWordList_fr\">s’[absenter]
-  (de)</option>
-
-  \                    <option class=\"opWordList_fr\">tout d'[abord]</option>
-
-  \                    <option class=\"opWordList_de\">[Absatz]/Stöckel der
-  Schuhe</option>
-
-  \                    <option class=\"opWordList_de\">[Abzug] (e-r
-  Feuerwaffe)</option>
-
-  \                    <option class=\"opWordList_de\">[Abzugsloch] unter der
-  Feuerstelle</option>
-
-  \                    <option class=\"opWordList_de\">[abgeschnittene] Locke
-  der Braut</option>
-
-  \                    <option class=\"opWordList_de\">[abgewinkelter]
-  Eingangsbereich tunesischer Häuser</option>
-
-  \                    <option class=\"opWordList_de\">[abschätziger] und
-  verächtlicher Mann</option>
-
-  \                    <option class=\"opWordList_de\">[abschüssige](r)
-  Straße/ Weg</option>
-
-  \                    <option class=\"opWordList_de\">des [Ablegens] von
-  Kleidung</option>
-
-  \                    <option class=\"opWordList_de\">die den Kachelfries
-  [abschließt]</option>
-
-  \                    <option class=\"opWordList_de\">eine große Schau
-  [abziehen]</option>
-
-  \                    <option class=\"opWordList_de\">j-m etw.
-  [abknöpfen]</option>
-
-  \                    <option class=\"opWordList_de\">j-m etw.
-  [abluchsen]</option>
-
-  \                    <option class=\"opWordList_de\">mit j-m
-  [abrechnen]</option>
-
-  \                    <option class=\"opWordList_en\">it is [absolutely]
-  necessary</option>
-
-  \                    <option class=\"opWordList_en\">to be passionate
-  [about]</option>
-
-  \                    <option class=\"opWordList_en\">to become
-  [abundant]/plentiful</option>
-
-  \                    <option class=\"opWordList_en\">to hang
-  [about]/around</option>
-
-  \                    <option class=\"opWordList_en\">to philosophize [about]
-  sth.</option>
-
-  \                    <option class=\"opWordList_en\">to wander
-  [about]/around</option>
-
-  \                    <option class=\"opWordList_fr\">avoir l'esprit
-  [absent]</option>
-
-  \                    <option class=\"opWordList_fr\">chevelure [abondante]
-  et indisciplinée</option>
-
-  \                    <option class=\"opWordList_fr\">il est [absolument]
-  necessaire</option>
-
-  \                    <option class=\"opWordList_de\">Schuheisen (für Spitze
-  und [Absatz])</option>
-
-  \                    <option class=\"opWordList_de\">Unterleder von Sohle
-  und [Absatz]</option>
-
-  \                    <option class=\"opWordList_de\">Wasch- und Wasserstelle
-  sowie [Abort]</option>
-
-  \                    <option class=\"opWordList_de\">[aber] geduldete)
-  Zuschauerin (bei Familienfeiern)</option>
-
-  \                    <option class=\"opWordList_de\">[abmessen] (mit e-m
-  Hohlmaß</option>
-
-  \                    <option class=\"opWordList_de\">an den Festtagen
-  Verwandtschaftsbesuche [absolviert])</option>
-
-  \                    <option class=\"opWordList_de\">befreien (verstopften
-  Gang/Kanal/[Abfluss]</option>
-
-  \                    <option class=\"opWordList_de\">der die einheimischen
-  Märkte [abmacht]</option>
-
-  \                    <option class=\"opWordList_de\">die das Trauerjahr
-  [abschließende] Zeremonie</option>
-
-  \                    <option class=\"opWordList_de\">mittels e-s Schlosses
-  [ab]-</option>
-
-  \                    <option class=\"opWordList_en\">to acquire knowledge
-  [about] sth.</option>
-
-  \                    <option class=\"opWordList_en\">to gossip [about]
-  sb./sth.</option>
-
-  \                    <option class=\"opWordList_en\">to perform the ritual
-  [ablution]</option>
-
-  \                    <option class=\"opWordList_en\">to talk [about]
-  sth./sb.</option>
-
-  \                    <option class=\"opWordList_de\">Feier zur schriftlichen
-  [Abfassung] eines Heiratsübereinkommens</option>
-
-  \                    <option class=\"opWordList_de\">Student bzw.
-  [Absolvent] der Zitouna-Hochschule</option>
-
-  \                    <option class=\"opWordList_de\">bei einer Prüfung
-  schummeln oder [abschreiben]</option>
-
-  \                    <option class=\"opWordList_de\">den Kuskusdämpfer
-  mittels der qfīla [abdichten]</option>
-
-  \                    <option class=\"opWordList_de\">sich [absichern] (durch
-  Rücklagen o. ä.)</option>
-
-  \                    <option class=\"opWordList_en\">to doubt of/[about]
-  sth./sb.</option>
-
-  \                    <option class=\"opWordList_fr\">employer [abondamment]
-  le mot pénis (zibb)</option>
-
-  \                    <option class=\"opWordList_de\">die als [Abgrenzung]
-  einer landwirtschaftlichen Fläche dienen</option>
-
-  \                    <option class=\"opWordList_de\">die gerne [abends]
-  ausgeht und gerne feiert</option>
-
-  \                    <option class=\"opWordList_de\">eifersüchtig auf die
-  [Abgeschlossenheit] seiner Frau Bedachter</option>
-
-  \                    <option class=\"opWordList_en\">a unit of mass ([about]
-  5 g)</option>
-
-  \                    <option class=\"opWordList_en\">to [abundantly] use the
-  word penis (zibb)</option>
-
-  \                    <option class=\"opWordList_en\">to say bad things
-  [about] sb./sth.</option>
-
-  \                    <option class=\"opWordList_de\">[aber] von Männern wie
-  Frauen unter sich gebraucht)</option>
-
-  \                    <option class=\"opWordList_de\">die Verbindung/den
-  Kontakt zu j-m [abbrechen]</option>
-
-  \                    <option class=\"opWordList_de\">bezüglich auf einen
-  Studenten bzw. [Absolventen] der Zitouna-Hochschule</option>
-
-  \                    <option class=\"opWordList_de\">das Fell von
-  Schlachttieren (an Schädel und Läufen) [absengen]</option>
-
-  \                    <option class=\"opWordList_en\">What do I/do you/does
-  he etc. think ([about]...)?</option>
-
-  \                    <option class=\"opWordList_de\">sehr feine und
-  geschmeidige Pantoffel mit [abgerundeter] Spitze und aus Kamelleder</option>
-
-  \                    <option class=\"opWordList_de\">und 9. Tag nach einem
-  Todesfall der leidtragenden Familie [abstattete] (obsoleter Brauch)</option>
-
-  \                    </div>
-
-  \        '500':
-
-  \          description: bad input parameter
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
-  \  /corpus:\ 
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: Search corpus
-
-  \      operationId: searchCorpus
-
-  \      description: |
-
-  \        By passing a well formed noSKE query as 'query' parameter, you can
-  retrieve serach results
-
-  \      parameters:
-
-  \        - in: query
-
-  \          name: query
-
-  \          description: query to perform against NoSKE
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: print
-
-  \          required: false
-
-  \          description: 'Whether to retrieve a full HTML file with
-  printer-friendly formatting.'
-
-  \          schema:
-
-  \            type: string
-
-  \      responses:
-
-  \        '200':
-
-  \          description: the transformed html
-
-  \          content:
-
-  \            application/json:
-
-  \              schema:
-
-  \                $ref: '#/components/schemas/CorpusSearch'
-
-  \              examples:\ 
-
-  \                corpus_search_json:
-
-  \                  summary: 'Corpus search results'
-
-  \                  value:\ 
-
-  \                    {
-
-  \                      \"query\":\"dār\",
-
-  \                      \"hits\":[
-
-  \                        {
-
-  \                          \"u\":\"URFA-077_a72\",
-
-  \                          \"doc\":\"URFA-077\",
-
-  \                          \"docHits\": [
-
-  \                            \"URFA-077_a72\"
-
-  \                          ],
-
-  \                          \"content\":\"<div
-  class=\\\"corpus-search-result\\\"
-  id=\\\"corpus-w-URFA-077_xTok_001078\\\"><div class=\\\"left\\\"><span
-  class=\\\"w\\\" id=\\\"URFA-077_xTok_001071\\\">āni<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-077_xTok_001072\\\">nāyim<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-077_xTok_001073\\\">hēne<\\/span><span xml:space=\\\"preserve\\\">
-  <\\/span><span class=\\\"w\\\" id=\\\"URFA-077_xTok_001074\\\">b<\\/span><span
-  class=\\\"w\\\" id=\\\"URFA-077_xTok_001076\\\">ad<\\/span><\\/div><div
-  class=\\\"keyword\\\"><span class=\\\"w\\\">dār<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><\\/div><div class=\\\"right\\\"><span
-  class=\\\"w\\\">haḏiyye<\\/span><span xml:space=\\\"preserve\\\">
-  <\\/span><span class=\\\"w\\\">nāyim<\\/span><span xml:space=\\\"preserve\\\">
-  <\\/span><\\/div><\\/div>\"
-
-  \                        },
-
-  \                        {
-
-  \                          \"u\":\"URFA-115_a4\",
-
-  \                          \"doc\":\"URFA-115\",
-
-  \                          \"docHits\": [\"URFA-115_a4\"],
-
-  \                          \"content\":\"<div
-  class=\\\"corpus-search-result\\\"
-  id=\\\"corpus-w-URFA-115_xTok_000096\\\"><div class=\\\"left\\\"><span
-  class=\\\"w\\\" id=\\\"URFA-115_xTok_000087\\\">rəḥalaw<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-115_xTok_000089\\\">xall<\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-115_xTok_000091\\\">ō<\\/span><span xml:space=\\\"preserve\\\">
-  <\\/span><span class=\\\"w\\\" id=\\\"URFA-115_xTok_000092\\\">b<\\/span><span
-  class=\\\"w\\\" id=\\\"URFA-115_xTok_000094\\\">ad<\\/span><\\/div><div
-  class=\\\"keyword\\\"><span class=\\\"w\\\">dār<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><\\/div><div class=\\\"right\\\"><span
-  class=\\\"w\\\">w<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
-  class=\\\"w\\\">šālaw<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
-  class=\\\"w\\\">eger<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
-  class=\\\"w\\\">miṯil<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
-  class=\\\"w\\\">al<\\/span><\\/div><\\/div>\"
-
-  \                        },
-
-  \                        {
-
-  \                          \"u\":\"URFA-122_a13\",
-
-  \                          \"docHits\": [\"URFA-122_a13\"],
-
-  \                          \"doc\":\"URFA-122\",
-
-  \                          \"content\":\"<div
-  class=\\\"corpus-search-result\\\"
-  id=\\\"corpus-w-URFA-122_xTok_000738\\\"><div class=\\\"left\\\"><span
-  class=\\\"w\\\" id=\\\"URFA-122_xTok_000730\\\">u<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-122_xTok_000731\\\">ˀal<\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-122_xTok_000733\\\">bāb<\\/span><span xml:space=\\\"preserve\\\">
-  <\\/span><span class=\\\"w\\\" id=\\\"URFA-122_xTok_000734\\\">b<\\/span><span
-  class=\\\"w\\\" id=\\\"URFA-122_xTok_000736\\\">ad<\\/span><\\/div><div
-  class=\\\"keyword\\\"><span class=\\\"w\\\">dār<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><\\/div><div class=\\\"right\\\"><span
-  class=\\\"w\\\">imčallṭīn<\\/span><span xml:space=\\\"preserve\\\">
-  <\\/span><span class=\\\"w\\\">al<\\/span><span
-  class=\\\"w\\\">qīrān<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
-  class=\\\"w\\\">aṭ<\\/span><span class=\\\"w\\\">ṭūg<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><\\/div><\\/div>\"
-
-  \                        },
-
-  \                        {
-
-  \                          \"u\":\"URFA-125_a9\",
-
-  \                          \"doc\":\"URFA-125\",
-
-  \                          \"docHits\": [\"URFA-125_a9\"],
-
-  \                          \"content\":\"<div
-  class=\\\"corpus-search-result\\\"
-  id=\\\"corpus-w-URFA-125_xTok_000258\\\"><div class=\\\"left\\\"><span
-  class=\\\"w\\\" id=\\\"URFA-125_xTok_000253\\\">hēn<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-125_xTok_000254\\\">ṛāyiḥ<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-125_xTok_000255\\\">āni<\\/span><span xml:space=\\\"preserve\\\">
-  <\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-125_xTok_000256\\\">ˀarīd<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\"
-  id=\\\"URFA-125_xTok_000257\\\">agḏ̣ub<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><\\/div><div class=\\\"keyword\\\"><span
-  class=\\\"w\\\">dār<\\/span><span xml:space=\\\"preserve\\\">
-  <\\/span><\\/div><div class=\\\"right\\\"><span
-  class=\\\"w\\\">aš<\\/span><span class=\\\"w\\\">šēx<\\/span><span
-  xml:space=\\\"preserve\\\"> <\\/span><span class=\\\"w\\\">w<\\/span><span
-  class=\\\"w\\\">arīd<\\/span><span xml:space=\\\"preserve\\\"> <\\/span><span
-  class=\\\"w\\\">āni<\\/span><span xml:space=\\\"preserve\\\">
-  <\\/span><\\/div><\\/div>\"
-
-  \                        }
-
-  \                      ]
-
-  \                    }
-
-  \         \ 
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: div
-
-  \                  wrapped: false
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: >\ 
-
-  \                    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-
-  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\"
-  xmlns:acdh=\"http://acdh.oeaw.ac.at\"
-  xmlns:tei=\"http://www.tei-c.org/ns/1.0\" class=\"corpus-search-results\">
-
-  \                        <h2 xml:space=\"preserve\">Search results for
-  dār</h2>
-
-  \                        <div class=\"corpus-search-result\"
-  id=\"corpus-w-URFA-077_xTok_001078\">
-
-  \                            <div class=\"left\">
-
-  \                                <span class=\"w\"
-  id=\"URFA-077_xTok_001071\">āni</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-077_xTok_001072\">nāyim</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-077_xTok_001073\">hēne</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-077_xTok_001074\">b</span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-077_xTok_001076\">ad</span>
-
-  \                            </div>
-
-  \                            <div class=\"keyword\">
-
-  \                                <span class=\"w\">dār</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                            </div>
-
-  \                            <div class=\"right\">
-
-  \                                <span class=\"w\">haḏiyye</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\">nāyim</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                            </div>
-
-  \                        </div>
-
-  \                        <div class=\"corpus-search-result\"
-  id=\"corpus-w-URFA-115_xTok_000096\">
-
-  \                            <div class=\"left\">
-
-  \                                <span class=\"w\"
-  id=\"URFA-115_xTok_000087\">rəḥalaw</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-115_xTok_000089\">xall</span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-115_xTok_000091\">ō</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-115_xTok_000092\">b</span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-115_xTok_000094\">ad</span>
-
-  \                            </div>
-
-  \                            <div class=\"keyword\">
-
-  \                                <span class=\"w\">dār</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                            </div>
-
-  \                            <div class=\"right\">
-
-  \                                <span class=\"w\">w</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\">šālaw</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\">eger</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\">miṯil</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\">al</span>
-
-  \                            </div>
-
-  \                        </div>
-
-  \                        <div class=\"corpus-search-result\"
-  id=\"corpus-w-URFA-122_xTok_000738\">
-
-  \                            <div class=\"left\">
-
-  \                                <span class=\"w\"
-  id=\"URFA-122_xTok_000730\">u</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-122_xTok_000731\">ˀal</span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-122_xTok_000733\">bāb</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-122_xTok_000734\">b</span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-122_xTok_000736\">ad</span>
-
-  \                            </div>
-
-  \                            <div class=\"keyword\">
-
-  \                                <span class=\"w\">dār</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                            </div>
-
-  \                            <div class=\"right\">
-
-  \                                <span class=\"w\">imčallṭīn</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\">al</span>
-
-  \                                <span class=\"w\">qīrān</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\">aṭ</span>
-
-  \                                <span class=\"w\">ṭūg</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                            </div>
-
-  \                        </div>
-
-  \                        <div class=\"corpus-search-result\"
-  id=\"corpus-w-URFA-125_xTok_000258\">
-
-  \                            <div class=\"left\">
-
-  \                                <span class=\"w\"
-  id=\"URFA-125_xTok_000253\">hēn</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-125_xTok_000254\">ṛāyiḥ</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-125_xTok_000255\">āni</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-125_xTok_000256\">ˀarīd</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\"
-  id=\"URFA-125_xTok_000257\">agḏ̣ub</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                            </div>
-
-  \                            <div class=\"keyword\">
-
-  \                                <span class=\"w\">dār</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                            </div>
-
-  \                            <div class=\"right\">
-
-  \                                <span class=\"w\">aš</span>
-
-  \                                <span class=\"w\">šēx</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\">w</span>
-
-  \                                <span class=\"w\">arīd</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                                <span class=\"w\">āni</span>
-
-  \                                <span xml:space=\"preserve\"></span>
-
-  \                            </div>
-
-  \                        </div>
-
-  \                    </div>
-
-  \        '500':
-
-  \          description: bad input parameter
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
-  \  /corpus_text:\ 
-
-  \    get:
-
-  \      tags:
-
-  \        - noauth
-
-  \      summary: Get rendered corpus text
-
-  \      operationId: getCorpusText
-
-  \      description: |
-
-  \        A pageable set of corpus utterances from the given text.
-
-  \      parameters:
-
-  \        - in: query
-
-  \          name: id
-
-  \          description: Corpus text ID
-
-  \          required: true
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: size
-
-  \          required: false
-
-  \          description: 'How many results to retrieve in one query. Defaults
-  to 10.'
-
-  \          schema:
-
-  \            type: number
-
-  \            default: 10
-
-  \        - in: query
-
-  \          name: page
-
-  \          required: false
-
-  \          description: 'Page number to retrieve. Defaults to 1.'
-
-  \          schema:
-
-  \            type: number
-
-  \            default: 1
-
-  \        - in: query
-
-  \          name: hits
-
-  \          description: Comma-separated token IDs to highlight
-
-  \          required: false
-
-  \          schema:
-
-  \            type: string
-
-  \        - in: query
-
-  \          name: print
-
-  \          required: false
-
-  \          description: 'Whether to retrieve a full HTML file with
-  printer-friendly formatting.'
-
-  \          schema:
-
-  \            type: string
-
-  \      responses:
-
-  \        '200':
-
-  \          description: the transformed html
-
-  \          content:
-
-  \            application/json:
-
-  \              schema:\ 
-
-  \                $ref: '#/components/schemas/CorpusText'
-
-  \              examples:\ 
-
-  \                corpustext_json:
-
-  \                  summary: sample json response
-
-  \                  value:
-
-  \                    {
-
-  \                      \"id\": \"$URFA-011\",
-
-  \                      \"utterances\": [
-
-  \                        {
-
-  \                          \"id\": \"URFA-011_a1\",
-
-  \                          \"content\": \"<div class=\\\"u\\\"
-  id=\\\"URFA-011_a1\\\" />\"
-
-  \                        },
-
-  \                        {
-
-  \                          \"id\": \"URFA-011_a2\",
-
-  \                          \"content\": \"<div class=\\\"u\\\"
-  id=\\\"URFA-011_a2\\\"><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000001\\\">hāḏa</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000002\\\">l</span><span>-</span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000004\\\">ᵊgbūr</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000005\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000006\\\">al</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000008\\\">miǧanne</span><span
-  class=\\\"pc\\\" id=\\\"xTok_000009\\\">,</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000010\\\">al</span><span>-</span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000012\\\">gabǝr</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000013\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000014\\\">wāḥad</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000015\\\">ymūt</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000016\\\">yidfunūn</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000018\\\">u</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000019\\\">hēne</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000020\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000021\\\">yidfunūn</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000023\\\">u</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000024\\\">yqasslūn</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000026\\\">u</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000027\\\">ʕala</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000028\\\">ʕurf</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000029\\\">islām</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000030\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000031\\\">ʕala</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000032\\\">ʕādāt</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000033\\\">uṣūl</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000034\\\">Islām</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000035\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000036\\\">yqassl</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000038\\\">u</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000039\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000040\\\">al</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000042\\\">xōǧe</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000043\\\">yqassl</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000045\\\">u</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000046\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000047\\\">w</span><span>-</span><span
-  class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000049\\\">yǧībūn</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000051\\\">u</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000052\\\">hēne</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000053\\\">yčaffnūn</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000055\\\">u</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000056\\\">yḥuṭṭūn</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000058\\\">u</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000059\\\">b</span><span>-</span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000061\\\">al</span><span>-</span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000063\\\">kefen</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000064\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000065\\\">čafan</span><span
-  class=\\\"pc\\\" id=\\\"xTok_000066\\\">–</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000067\\\">kefen</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000068\\\">–</span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000069\\\">čafan</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000070\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000071\\\">ydummūn</span><span>-</span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000073\\\">u</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000074\\\">.</span><span xml:space=\\\"preserve\\\">
-  </span></div>\"
-
-  \                        },
-
-  \                        {
-
-  \                          \"id\": \"URFA-011_a3\",
-
-  \                          \"content\": \"<div class=\\\"u\\\"
-  id=\\\"URFA-011_a3\\\"><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000075\\\">al</span><span>-</span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000077\\\">gabǝr</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000078\\\">baʕdēn</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000079\\\">,</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000080\\\">ʕugub</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000081\\\">sabʕ</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000082\\\">ᵊsnīn</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000083\\\">yigdarūn</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000084\\\">yḥuṭṭūn</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000085\\\">qēr</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000086\\\">wāḥad</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000087\\\">bī</span><span>-</span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000089\\\">´</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000090\\\">.</span><span xml:space=\\\"preserve\\\"> </span><span
-  class=\\\"w\\\" id=\\\"URFA-011_xTok_000091\\\">in</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000092\\\">mā</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000093\\\">ṣār</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000094\\\">sabʕ</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000095\\\">ᵊsnīn</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000096\\\">qēr</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\" id=\\\"URFA-011_xTok_000097\\\">wāḥad</span><span
-  xml:space=\\\"preserve\\\"> </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000098\\\">mā</span><span xml:space=\\\"preserve\\\">
-  </span><span class=\\\"w\\\"
-  id=\\\"URFA-011_xTok_000099\\\">yḥuṭṭūn</span><span class=\\\"pc\\\"
-  id=\\\"xTok_000100\\\">.</span><span xml:space=\\\"preserve\\\">
-  </span></div>\"
-
-  \                        }
-
-  \                      ]
-
-  \                    }
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \                xml:
-
-  \                  name: div
-
-  \                  wrapped: false
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: >\ 
-
-  \                    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-
-  \                    <div xmlns=\"http://www.w3.org/1999/xhtml\"
-  xmlns:acdh=\"http://acdh.oeaw.ac.at\"
-  xmlns:tei=\"http://www.tei-c.org/ns/1.0\" class=\"corpus-utterances\">
-
-  \                        <div class=\"u\" id=\"URFA-011_a3\">
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000075\">al</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000077\">gabǝr</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000078\">baʕdēn</span>
-
-  \                            <span class=\"pc\" id=\"xTok_000079\">,</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000080\">ʕugub</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000081\">sabʕ</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000082\">ᵊsnīn</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000083\">yigdarūn</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000084\">yḥuṭṭūn</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000085\">qēr</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000086\">wāḥad</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000087\">bī</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000089\">´</span>
-
-  \                            <span class=\"pc\" id=\"xTok_000090\">.</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000091\">in</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000092\">mā</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000093\">ṣār</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000094\">sabʕ</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000095\">ᵊsnīn</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000096\">qēr</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000097\">wāḥad</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000098\">mā</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000099\">yḥuṭṭūn</span>
-
-  \                            <span class=\"pc\" id=\"xTok_000100\">.</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                        </div>
-
-  \                        <div class=\"u\" id=\"URFA-011_a4\">
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000101\">ta</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000103\">ngūl</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000104\">hāḏa</span>
-
-  \                            <span class=\"pc\" id=\"xTok_000105\">,</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000106\">mayyit</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000107\">luwwa</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000108\">sine</span>
-
-  \                            <span class=\"pc\" id=\"xTok_000109\">,</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000110\">al</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000112\">gabǝr</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000113\">hāḏa</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000114\">mā</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000115\">yiftaḥūn</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000117\">u</span>
-
-  \                            <span class=\"pc\" id=\"xTok_000118\">–</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000119\">mā</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000120\">yiftaḥūn</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000122\">u</span>
-
-  \                            <span class=\"pc\" id=\"xTok_000123\">–</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000124\">baˁad</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000125\">sabˁ</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000126\">ᵊsnīn</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000127\">yiftaḥūn</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000129\">u</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000130\">yigdarūn</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000131\">in</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000132\">māt</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000133\">ḥade</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000134\">in</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000135\">ṣār</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000136\">mayyit</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000137\">uxṛa</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000138\">l</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000140\">al</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000142\">ˁēle</span>
-
-  \                            <span class=\"pc\" id=\"xTok_000143\">,</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000144\">kull</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000146\">min</span>
-
-  \                            <span class=\"pc\" id=\"xTok_000147\">…</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000148\">ta</span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000150\">ngūl</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000151\">alḥaz</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                            <span class=\"w\"
-  id=\"URFA-011_xTok_000152\">iḥna</span>
-
-  \                            <span xml:space=\"preserve\"></span>
-
-  \                        </div>
-
-  \                    </div>
-
-  \        '500':
-
-  \          description: bad input parameter
-
-  \          content:
-
-  \            application/xml:
-
-  \              schema:
-
-  \                type: string
-
-  \              examples:
-
-  \                html:
-
-  \                  summary: A sample HTML response
-
-  \                  value: '<html><body><ul><li>item 1</li><li>item
-  2</li></ul></body></html>'
-
+    /vicav/project:
+      get:
+        description: Get info about the project, menus and open panels/windows
+        tags:
+          - noauth
+        summary: gets basic project configuration
+        operationId: getProject
+        responses:
+          '200':
+            description: an xml with wrapped html contained
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ProjectConfig'
+                examples:
+                  project_config_JSON:
+                    summary: the project configuration
+                    value: {
+                      "projectConfig": {
+                        "title": "VICAV3.0 - Vienna Corpus of Arabic Varieties",
+                        "logo": {
+                          "img": "images\/vicav_logo.svg"
+                        },
+                        "param": [
+                          ".*",
+                          "geo"
+                        ],
+                        "panel": [
+                          {
+                            "type": "text",
+                            "target": "li_vicavMission",
+                            "title": "MISSION"
+                          },
+                          {
+                            "type": "text",
+                            "target": "li_vicavNews",
+                            "title": "NEWS"
+                          }
+                        ],
+                        "menu": {
+                          "main": [
+                            {
+                              "id": "dropdown00",
+                              "title": "Project",
+                              "item": [
+                                {
+                                  "id": "li_vicavMission",
+                                  "title": "Mission",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavNews",
+                                  "title": "News",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "li_vicavTypesOfText",
+                                  "title": "Types of Text\/Data",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavContributors",
+                                  "title": "Contributors",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavLinguistics",
+                                  "title": "Linguistics",
+                                  "type": "item"
+                                }
+                              ],
+                              "type": "dropdown"
+                            },
+                            {
+                              "id": "dropdown01",
+                              "title": "Bibliographies",
+                              "item": [
+                                {
+                                  "id": "li_vicavExplanationBibliography",
+                                  "title": "Explanation",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "navBiblGeoMarkers",
+                                  "title": "All Bibl. Locations on Map",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "navBiblRegMarkers",
+                                  "title": "All Bibl. Regions on Map",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "navDictGeoRegMarkers",
+                                  "title": "All Dictionaries in Bibl. on Map",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "navTextbookGeoRegMarkers",
+                                  "title": "All Textbooks in Bibl. on Map",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "liBiblNewQuery",
+                                  "title": "Query Bibliography",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "li_vicavContributeBibliography",
+                                  "title": "Contribute to the Bibliography",
+                                  "type": "item"
+                                }
+                              ],
+                              "type": "dropdown"
+                            },
+                            {
+                              "id": "dropdown02",
+                              "title": "Profiles",
+                              "item": [
+                                {
+                                  "id": "li_vicavExplanationProfiles",
+                                  "title": "Explanation + List",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "navProfilesGeoRegMarkers",
+                                  "title": "Show All Profiles on Map",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "li_vicavContributeProfile",
+                                  "title": "Contribute a Profile",
+                                  "type": "item"
+                                }
+                              ],
+                              "type": "dropdown"
+                            },
+                            {
+                              "id": "dropdown03",
+                              "title": "Feature Lists",
+                              "item": [
+                                {
+                                  "id": "li_vicavExplanationFeatures",
+                                  "title": "Explanation",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "liVicavCrossFeatureQuery",
+                                  "title": "Cross-examine the VICAV Feature Lists",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "navFeaturesGeoRegMarkers",
+                                  "title": "Show All Feature Lists on Map",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "li_vicavContributeFeature",
+                                  "title": "Contribute a Feature List",
+                                  "type": "item"
+                                }
+                              ],
+                              "type": "dropdown"
+                            },
+                            {
+                              "id": "dropdown04",
+                              "title": "Samples",
+                              "item": [
+                                {
+                                  "id": "li_vicavExplanationSamples",
+                                  "title": "Explanation",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "navSamplesGeoRegMarkers",
+                                  "title": "Show All Samples on Map",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "liExploreSamples",
+                                  "title": "Compare Locations",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "li_vicavContributeSampleText",
+                                  "title": "Contribute a Sample Text",
+                                  "type": "item"
+                                }
+                              ],
+                              "type": "dropdown"
+                            },
+                            {
+                              "id": "dropdown05",
+                              "title": "Texts",
+                              "item": [
+                                {
+                                  "id": "li_vicavExplanationCorpusTexts",
+                                  "title": "Explanation and Overview",
+                                  "type": "item"
+                                }
+                              ],
+                              "type": "dropdown"
+                            },
+                            {
+                              "id": "dropdown06",
+                              "title": "Dictionaries",
+                              "item": [
+                                {
+                                  "id": "navDictGeoRegMarkers",
+                                  "title": "All Dictionaries in Bibl. on Map",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "navVicavDictMarkers",
+                                  "title": "All VICAV Dictionaries on Map",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "liVicavCrossDictQuery",
+                                  "title": "Query the VICAV Dictionaries",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "liVicavDict_Tunis",
+                                  "title": "TUNICO Dictionary",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "liVicavDict_Damascus",
+                                  "title": "Damascus Dictionary",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "liVicavDict_Cairo",
+                                  "title": "Cairo Dictionary",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "liVicavDict_Baghdad",
+                                  "title": "Baghdad Dictionary",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "liVicavDict_MSA",
+                                  "title": "MSA Dictionary",
+                                  "type": "item"
+                                },
+                                {
+                                  "type": "separator"
+                                },
+                                {
+                                  "id": "li_vicavDictionariesTechnicalities",
+                                  "title": "Technicalities",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavContributeDictionary",
+                                  "title": "Contribute a Dictionary\/Glossary",
+                                  "type": "item"
+                                }
+                              ],
+                              "type": "dropdown"
+                            },
+                            {
+                              "id": "dropdown07",
+                              "title": "Tools & Technology",
+                              "item": [
+                                {
+                                  "id": "li_vicavDictionaryEncoding",
+                                  "title": "Dictionary Encoding",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavVLE",
+                                  "title": "Dictionary Editor (VLE)",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavArabicTools",
+                                  "title": "Arabic Research Tools",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavOverview_corpora_spoken",
+                                  "title": "      Corpora (Spoken Varieties)",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavOverview_corpora_msa",
+                                  "title": "      Corpora (MSA)",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavOverview_special_corpora",
+                                  "title": "      Special Corpora",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavOverview_corpora_historical_varieties",
+                                  "title": "      Corpora (Historical Varieties)",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavOverview_dictionaries",
+                                  "title": "      Dictionaries",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavOverview_nlp",
+                                  "title": "      Language Processing Tools",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavOverview_otherStuff",
+                                  "title": "      Other Websites & Projects",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavLearning",
+                                  "title": "Learning Materials",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavLearning_tb_damascus",
+                                  "title": "      Textbook Syrian Arabic (Sound files)",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavLearningSmartphone",
+                                  "title": "      Vocabularies on Smartphones",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavLearningPrograms",
+                                  "title": "      Available Programs",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavLearningData",
+                                  "title": "      Available Data",
+                                  "type": "item"
+                                },
+                                {
+                                  "id": "li_vicavKeyboards",
+                                  "title": "Keyboard Layouts",
+                                  "type": "item"
+                                }
+                              ],
+                              "type": "dropdown"
+                            }
+                          ],
+                          "subnav": [
+                            {
+                              "id": "subNavBiblGeoMarkers",
+                              "class": "active",
+                              "title": "Bibl. Locations",
+                              "type": "item"
+                            },
+                            {
+                              "id": "subNavBiblRegMarkers",
+                              "title": "Bibl. Regions",
+                              "type": "item"
+                            },
+                            {
+                              "id": "subNavDictGeoRegMarkers",
+                              "title": "Bibl. (Dictionaries)",
+                              "type": "item"
+                            },
+                            {
+                              "id": "subNavTextbookGeoRegMarkers",
+                              "title": "Bibl. (Textbooks)",
+                              "type": "item"
+                            },
+                            {
+                              "id": "subNavProfilesGeoRegMarkers",
+                              "title": "Profiles",
+                              "type": "item"
+                            },
+                            {
+                              "id": "subNavFeaturesGeoRegMarkers",
+                              "title": "Features",
+                              "type": "item"
+                            },
+                            {
+                              "id": "subNavSamplesGeoRegMarkers",
+                              "title": "Samples",
+                              "type": "item"
+                            },
+                            {
+                              "id": "subNavVicavDictMarkers",
+                              "title": "VICAV Dictionaries",
+                              "type": "item"
+                            }
+                          ]
+                        }
+                      }
+                    }
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: project
+                    wrapped: false
+                examples:
+                  project_config_XML_and_rendered_XHTML:
+                    summary: the project configuration
+                    value: >
+                      <project>
+                        <config>
+                          <projectConfig xml:space="preserve" id="vicav_config_vicav">
+                        <title>VICAV3.0 - Vienna Corpus of Arabic Varieties</title>
+                        <logo><img src="images/vicav_logo.svg"/></logo>
+                        <frontpage method="geo">
+                          <param>.*</param>
+                          <param>geo</param>
+                          <panel type="text" target="li_vicavMission">MISSION</panel>
+                          <panel type="text" target="li_vicavNews">NEWS</panel>
+                        </frontpage>
+                        <menu>
+                          <main>
+                            <dropdown xml:id="dropdown00" title="Project">
+                              <item xml:id="li_vicavMission">Mission</item>
+                              <item xml:id="li_vicavNews">News</item>
+                              <separator/>
+                              <item xml:id="li_vicavTypesOfText">Types of Text/Data</item>
+                              <item xml:id="li_vicavContributors">Contributors</item>
+                              <item xml:id="li_vicavLinguistics">Linguistics</item>
+                            </dropdown>
+                          </main>
+                          <subnav>
+                            <item xml:id="subNavBiblGeoMarkers" class="active">Bibl. Locations</item>
+                          </subnav>
+                        </menu>
+                      </projectConfig>
+                        </config>
+                        <renderedMenu>
+                          <menu xmlns="http://www.w3.org/1999/xhtml">
+                            <main>
+                              <ul class="navbar-nav mr-auto">
+                                <li class="nav-item dropdown">
+                                  <a class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdown00">Project</a>
+                                  <div class="dropdown-menu" aria-labelledby="dropdown00">
+                                    <a class="dropdown-item" id="li_vicavMission">Mission</a>
+                                    <a class="dropdown-item" id="li_vicavNews">News</a>
+                                    <div class="dropdown-divider"/>
+                                    <a class="dropdown-item" id="li_vicavTypesOfText">Types of Text/Data</a>
+                                    <a class="dropdown-item" id="li_vicavContributors">Contributors</a>
+                                    <a class="dropdown-item" id="li_vicavLinguistics">Linguistics</a>
+                                  </div>
+                                </li>
+                              </ul>
+                            </main>
+                            <subnav xmlns="">
+                              <span xmlns="http://www.w3.org/1999/xhtml" xml:space="preserve" id="subNavBiblGeoMarkers"><i class="fa fa-map" aria-hidden="true"/> Bibl. Locations</span>
+                            </subnav>
+                          </menu>
+                        </renderedMenu>
+                      </project>
+    /vicav/text:
+      get:
+        tags:
+          - noauth
+        summary: gets a description text identtified by its tei:div@xml:id
+        operationId: getText
+        description: |
+          By passing the appropriate xml-ID and xslt you can retrieve ready to display html
+        parameters:
+          - in: query
+            name: id
+            description: the @xml:id of the tei:div xml element
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: xslt
+            required: false
+            description: the filename of the xslt transformation (for development purposes only)
+            schema:
+              type: string
+        responses:
+          '200':
+            description: the transformed html
+            content:
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: div
+                    wrapped: false
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: >
+                      <div xmlns:tei="http://www.tei-c.org/ns/1.0">
+
+                      <table class="tbHeader">
+                      <tr>
+                      <td>
+                      <h2>Sample Texts (Explanation)</h2>
+                      </td>
+                      <td>{teiLink}</td>
+                      </tr>
+                      </table>
+
+
+                      <p>The sample texts are translations of the same
+                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:msa_sample_01/Modern Standard Arabic&#34;, this)">source text</a>. They vary slightly with respect to regional
+                      differences. However, they are homogeneous enough to allow students to
+                      compare the numerous linguistic phenomena displayed in the texts.</p>
+
+
+                      <p>Sofar we provide sample texts for six locations:
+                      <ul>
+
+                      <li>
+                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:baghdad_sample_01/Baghdad&#34;, this)">Baghdad</a>
+                      </li>
+
+                      <li>
+                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:cairo_sample_01/Cairo&#34;, this)">Cairo</a>
+                      </li>
+
+                      <li>
+                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:damascus_sample_01/Damascus&#34;, this)">Damascus</a>
+                      </li>
+
+                      <li>
+                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:douz_sample_01/Douz&#34;, this)">Douz</a>
+                      </li>
+
+                      <li>
+                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:urfa_sample_01/%C5%9Eanl%C4%B1urfa&#34;, this)">Şanlıurfa</a>
+                      </li>
+
+                      <li>
+                      <a class="aVicText" href="javascript:getDBSnippet(&#34;sample:tunis_sample_01/Tunis&#34;, this)">Tunis</a>
+                      </li>
+                      </ul>
+                      </p>
+                      </div>
+          '500':
+            description: bad input parameter
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+    /vicav/profile:
+      get:
+        tags:
+          - noauth
+        summary: gets a langauge profile identified by its TEI@xml:id
+        operationId: getProfile
+        description: |
+          By passing the appropriate xml-ID and xslt you can retrieve ready to display html
+        parameters:
+          - in: query
+            name: id
+            description: the @xml:id of the TEI xml element
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: coll
+            description: the id of the collection/database to use (for development purposes only)
+            required: false
+            schema:
+              type: string
+          - in: query
+            name: xslt
+            required: false
+            description: the filename of the xslt transformation (for development purposes only)
+            schema:
+              type: string
+        responses:
+          '200':
+            description: the transformed html
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: >
+                      <div xmlns="http://www.w3.org/1999/xhtml" xmlns:tei="http://www.tei-c.org/ns/1.0">
+                      <table class="tbHeader">
+                      <tr>
+                      <td>
+                      <h2>Skoura</h2>
+                      </td>
+                      <td class="tdTeiLink">{teiLink}</td>
+                      </tr>
+                      </table>
+                      <div class="profileHeader">
+                      <div class="dvImgProfile"><img src="images/skoura_sp_2012.jpg"><div class="imgCaption">Courtesy of Stephan Procházka, 2012</div>
+                      </div>
+                      <table class="tbProfile">
+                      <tr>
+                      <td class="tdHead">MSA Name</td>
+                      <td class="tdProfileTableRight">سكورة</td>
+                      </tr>
+                      <tr>
+                      <td class="tdHead">MSA Name (trans.)</td>
+                      <td class="tdProfileTableRight">Sakūra Skūra</td>
+                      </tr>
+                      <tr>
+                      <td class="tdHead">Geo location</td>
+                      <td class="tdProfileTableRight"><i>
+                      31°03'N 06°33'W
+                      Morocco
+                      </i></td>
+                      </tr>
+                      <tr>
+                      <td class="tdHead">Contributed by</td>
+                      <td class="tdProfileTableRight"><i>Aleksandra Ercegovčević</i></td>
+                      </tr>
+                      </table>
+                      </div>
+                      <div class="h3ProfileTypology">Typology</div>
+                      <table class="tbProfile">
+                      <tr>
+                      <td colspan="2" class="tdProfileTableRight">West (Maghreb) › Morocco › Central type</td>
+                      </tr>
+                      <tr>
+                      <td colspan="2" class="tdProfileTableRight">Hilalian-type sedentary rural dialect with strong influence of Berber</td>
+                      </tr>
+                      </table>
+                      <div class="h3Profile">General</div>
+
+                      <div class="pNorm">Skūra is an Arabic enclave in the Berber-speaking area south of the High Atlas. Many
+                      of the 15,000 inhabitants are bilingual. They live mainly on agriculture and stock
+                      breeding.</div>
+
+                      <div class="h3Profile">Research History</div>
+
+                      <div class="pNorm">All available data on the dialect of Skūra is from the work of Jorge Aguadé and Mohammad
+                      Elyaâcoubi. <a class="aVicText" href="javascript:getDBSnippet(&#34;zotid:8SISG2GK&#34;)">Aguadé 1994</a> is a brief study on the formation of the reflexive-passive forms of the verb. <a class="aVicText" href="javascript:getDBSnippet(&#34;zotid:E3T3HBCD&#34;)">Aguadé and Elyaacoubi 1995</a> is a monograph on the dialect with chapters on phonology, nominal and verbal morphology,
+                      and verb paradigms. <a class="aVicText" href="javascript:getDBSnippet(&#34;zotid:I3FIKENT&#34;)">Aguadé et al. 1996</a> deals with the irrigation system in the oasis of Skūra, and the technical terminology
+                      concerning irrigation in the dialect of Skūra. Elyaâcoubi 1998 treats the topic of
+                      the classification of south Moroccan Arabic dialects on the example of Skūra, where
+                      a three page-grammatical sketch of the dialect is also provided.</div>
+
+                      <div class="h3Profile">Dictionaries</div>
+
+                      <div class="pNorm"><a class="aVicText" href="javascript:getDBSnippet(&#34;zotid:I3FIKENT&#34;)">Aguadé et al. 1996</a> includes a 2-page glossary of terminology related to the irrigation system (<i>xiṭṭāra</i>).</div>
+
+                      <div class="h3Profile">Bibliography</div>
+
+                      <div class="pNorm">To view publications on this variety click <a class="aVicText" href="javascript:getDBSnippet(&#34;bibl:geo:Skoura&#34;)">here</a>.</div>
+                      <br><br><br></div>
+          '500':
+            description: bad input parameter
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+    /vicav/explore_samples:
+      get:
+        tags:
+          - noauth
+        summary: gets a specific html transformed via a specified xslt
+        operationId: getExploreSamples
+        description: |
+          By passing the appropriate xml-ID and xslt you can retrieve ready to display html
+        parameters:
+          - in: query
+            name: type
+            description: the type of query?
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: word
+            description: the word to search for?
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: xslt
+            required: false
+            description: the filename of the xslt transformation (for development purposes only)
+            schema:
+              type: string
+        responses:
+          '200':
+            description: the transformed html
+            content:
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: div
+                    wrapped: false
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<div xmlns="http://www.w3.org/1999/xhtml" xmlns:tei="http://www.tei-c.org/ns/1.0"><div class="explore-samples"><table class="tbHeader"><tr><td><h2 xml:space="preserve">Compare samples</h2></td><td class="tdPrintLink"><a href="#" data-print="true" class="aTEIButton">Print</a></td></tr></table><div class="explore-samples-summary"><h4>Summary</h4><table><tr><th>unknown</th><td>1</td></tr></table></div><h3>3</h3><h4>unknown</h4><p xml:space="preserve">1 sentences found.</p><table class="tbFeatures"><tr><td class="tdFeaturesHeadRight"><small xml:space="preserve">%as</small></td><td class="tdFeaturesRightTarget"><a class="show-sentence" title="Show full sample text" href="#" data-sampletext="douz_sample_01"><i class="fa fa-eye" aria-hidden="true"><span/></i></a><span xmlns:acdh="http://acdh.oeaw.ac.at" class="spSentence" xml:space="preserve"><span class="sample-text-tooltip" data-html="true" data-toggle="tooltip" data-placement="top" title="Tomaten nahm ich keine, weil sie sehr teuer&#xA;                     waren."><i class="fa fa-commenting-o" aria-hidden="true"><span/></i></span> <a class="word-search" href="#" data-wordform="mā" data-type="sample"><span data-html="true" data-placement="top" class="w">mā</span></a><a class="word-search" href="#" data-wordform="-" data-type="sample"><span data-html="true" data-placement="top" class="w">-</span></a><a class="word-search" href="#" data-wordform="šrīt" data-type="sample"><span data-html="true" data-placement="top" class="w highlight">šrīt</span></a><a class="word-search" href="#" data-wordform="-" data-type="sample"><span data-html="true" data-placement="top" class="w">-</span></a><a class="word-search" href="#" data-wordform="ǝš" data-type="sample"><span data-html="true" data-placement="top" class="w">ǝš</span></a> <a class="word-search" href="#" data-wordform="iṭ" data-type="sample"><span data-html="true" data-placement="top" class="w">iṭ</span></a><a class="word-search" href="#" data-wordform="-" data-type="sample"><span data-html="true" data-placement="top" class="w">-</span></a><a class="word-search" href="#" data-wordform="ṭamāṭim" data-type="sample"><span data-html="true" data-placement="top" class="w">ṭamāṭim</span></a> <a class="word-search" href="#" data-wordform="ʿal" data-type="sample"><span data-html="true" data-placement="top" class="w">ʿal</span></a><a class="word-search" href="#" data-wordform="-" data-type="sample"><span data-html="true" data-placement="top" class="w">-</span></a><a class="word-search" href="#" data-wordform="xāṭir" data-type="sample"><span data-html="true" data-placement="top" class="w">xāṭir</span></a> <a class="word-search" href="#" data-wordform="kānat" data-type="sample"><span data-html="true" data-placement="top" class="w">kānat</span></a> <a class="word-search" href="#" data-wordform="ġālya" data-type="sample"><span data-html="true" data-placement="top" class="w">ġālya</span></a><a class="word-search" href="#" data-wordform="." data-type="sample"><span data-html="true" data-placement="top" class="w">.</span></a> </span></td></tr></table></div></div>'
+          '500':
+            description: bad input parameter
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+    /vicav/biblio_tei:
+      get:
+        tags:
+          - noauth
+        summary: gets a specific html transformed via a specified xslt
+        operationId: getBiblioTei
+        description: |
+          By passing a well formed query and xslt you can retrieve ready to display html
+        parameters:
+          - in: query
+            name: query
+            description: the query
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: xslt
+            required: false
+            description: the filename of the xslt transformation (for development purposes only)
+            schema:
+              type: string
+        responses:
+          '200':
+            description: the transformed html
+            content:
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: div
+                    wrapped: false
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<div xmlns:tei="http://www.tei-c.org/ns/1.0"><div class="dvStats">Query:  <span class="spQueryText">{query}</span></div><div class="dvStats">1 record </div><div class="dvBibBook"><div class="dvAuthor"><b>Hagenbucher,<span xml:space="preserve"> </span>F.</b></div><div class="dvBiblBlock"><img class="imgBiblItem" src="images/book_001.jpg"/>Les arabes dits “suwa” du Nord-Cameroun.<span xml:space="preserve"> </span>Yaounde.<span xml:space="preserve"> </span>ORSTOM.<span xml:space="preserve"> </span>1973.</div></div></div>'
+          '500':
+            description: bad input parameter
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+    /vicav/bibl_markers_tei:
+      get:
+        tags:
+          - noauth
+        summary: gets a geo marker information 
+        operationId: getMarkers
+        description: |
+          Retrieve geo data information from the bibliography for displaying coordinates on a map.
+        parameters:
+          - in: query
+            name: query
+            description: |
+              A BaseX Full-Text search query in in vicav-biblio tei:biblstruct with wildcards enabled.
+              See: https://docs.basex.org/wiki/Full-Text#Match_Options
+              using wildcards using diacritics sensitive
+              Uses prefixes to limit the full text search to certein elements.
+              * date: -> tei:date
+              * title: -> tei:title
+              * pubPlace: -> tei:pubPlace
+              * author: -> tei:author/tei:surname
+              * geo:, geo_reg:, reg:, diaGroup: -> tei:note[@type="tag"]/tei:name
+              * vt:, prj: -> tei:note[@type="tag"]
+              
+              Without a prefix any text in vicav-biblio tei:biblstruct is searched.
+              
+              More than one query is possible by separating with ' '/+.
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: scope
+            required: true
+            description: |
+              Filters based on a set of tei:name/@types being present in a tei:note[tei:geo]           
+              * geo
+              * diaGroup
+              * reg
+              * geo_reg: any of the above
+            schema:
+              type: string            
+              enum:
+              - geo_reg
+              - geo
+              - reg
+              - diaGroup
+        responses:
+          '200':
+            description: a list of geo markers
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    type: object
+                    schema:
+                      $ref: '#/components/schemas/Feature'
+                examples:
+                  geoJSON_features_Ma_geo_reg:
+                    summary: 'query: Ma.*. scope: geo_reg, shorted'
+                    value: [
+                            {
+                              "type": "Feature",
+                              "geometry": {
+                                "type": "Point",
+                                "coordinates": [
+                                  "35.578333",
+                                  "-5.368056"
+                                ]
+                              },
+                              "properties": {
+                                "type": "geo",
+                                "name": "Tétouan",
+                                "hitCount": "16"
+                              }
+                            },
+                            {
+                              "type": "Feature",
+                              "geometry": {
+                                "type": "Point",
+                                "coordinates": [
+                                  "32.000000",
+                                  "-6.000000"
+                                ]
+                              },
+                              "properties": {
+                                "type": "reg",
+                                "name": "Morocco",
+                                "hitCount": "1157"
+                              }
+                            }
+                          ]
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: rs
+                    wrapped: false
+                  items:
+                    type: object
+                examples:
+                  xml:
+                    summary: a list of geo markers
+                    value: >
+                      <rs type="60">
+                        <r type="geo">
+                          <geo>35.578333 -5.368056</geo>
+                          <alt>Tétouan</alt>
+                          <freq>1</freq>
+                        </r>
+                        <r type="reg">
+                          <geo>32.000000 -6.000000</geo>
+                          <alt>Morocco</alt>
+                          <freq>44</freq>
+                        </r>
+                        <r type="reg">
+                          <geo>34.000000 9.000000</geo>
+                          <alt>Tunisia</alt>
+                          <freq>4</freq>
+                        </r>
+                      </rs>
+          '500':
+            description: bad input parameter
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+    /vicav/{name}_markers:
+      get:
+        tags:
+          - noauth
+        summary: gets a specific xml
+        operationId: sampleMarkers
+        description: |
+          I have no idea
+        parameters:
+          - in: path
+            name: name
+            description: a reference to a predefined query?
+            required: true
+            schema:
+              type: string
+        responses:
+          '200':
+            description: an xml result list
+            content:
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: rs
+                    wrapped: false
+                  items:
+                    type: object
+                examples:
+                  xml:
+                    summary: A list of geo markers
+                    value: >
+                      <rs>
+                        <r type="geo" xml:id="baghdad_sample_01">
+                          <loc>33°20'N 44°24'E</loc>
+                          <locName>
+                            <name xmlns="http://www.tei-c.org/ns/1.0" xml:lang="eng">Baghdad</name>
+                          </locName>
+                          <alt>
+                            <name xmlns="http://www.tei-c.org/ns/1.0" xml:lang="eng">Baghdad</name>
+                          </alt>
+                          <freq>1</freq>
+                        </r>
+                        <r type="geo" xml:id="cairo_sample_01">
+                          <loc>30°03'N 31°14'E</loc>
+                          <locName>
+                            <name xmlns="http://www.tei-c.org/ns/1.0" xml:lang="eng">Cairo</name>
+                          </locName>
+                          <alt>
+                            <name xmlns="http://www.tei-c.org/ns/1.0" xml:lang="eng">Cairo</name>
+                          </alt>
+                          <freq>1</freq>
+                        </r>
+                      </rs>
+          '404':
+            description: not found
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+    /vicav/dict_api:
+      get:
+        tags:
+          - noauth
+        summary: gets a specific html transformed via a specified xslt
+        operationId: getDictApi
+        description: |
+          By passing a well formed query and xslt you can retrieve ready to display html
+        parameters:
+          - in: query
+            name: query
+            description: the query
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: dict
+            description: the dict id?
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: xslt
+            required: false
+            description: the filename of the xslt transformation (for development purposes only)
+            schema:
+              type: string
+        responses:
+          '200':
+            description: the transformed html
+            content:
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: div
+                    wrapped: false
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: >
+                      <div xmlns="http://www.w3.org/1999/xhtml" xmlns:tei="http://www.tei-c.org/ns/1.0">
+                      <div class="dvStats" id="dvStats">0&nbsp;hits</div>
+                      </div>
+          '500':
+            description: bad input parameter
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+    /vicav/dict_index:
+      get:
+        tags:
+          - noauth
+        summary: gets a specific html transformed via a specified xslt
+        operationId: getDictIndex
+        description: |
+          By passing a well formed query you can retrieve ready to display html
+        parameters:
+          - in: query
+            name: dict
+            description: the dict id?
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: ind
+            required: true
+            description: I have no idea
+            schema:
+              type: string
+              enum:
+                - any
+                - lem
+                - infl
+                - en
+                - de
+                - fr
+                - pos
+                - root
+                - subc
+                - etymSrc
+                - etymLang
+          - in: query
+            name: str
+            required: true
+            description: the query string?
+            schema:
+              type: string
+        responses:
+          '200':
+            description: the transformed html
+            content:
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: div
+                    wrapped: false
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: >
+                      <div xmlns="http://www.w3.org/1999/xhtml">
+                      <option class="opWordList_de">'[abstauben]</option>
+                      <option class="opWordList_de">[Abbilden]</option>
+                      <option class="opWordList_de">[Abdruck]</option>
+                      <option class="opWordList_de">[Abend]</option>
+                      <option class="opWordList_de">[Abend]-</option>
+                      <option class="opWordList_de">[Abendessen]</option>
+                      <option class="opWordList_de">[Abendgebet]</option>
+                      <option class="opWordList_de">[Abenteuer]</option>
+                      <option class="opWordList_de">[Abfall]</option>
+                      <option class="opWordList_de">[Abfallhaufen]</option>
+                      <option class="opWordList_de">[Abflussloch]</option>
+                      <option class="opWordList_de">[Abflussrinne]</option>
+                      <option class="opWordList_de">[Abflussrohr]</option>
+                      <option class="opWordList_de">[Abflußkanal]</option>
+                      <option class="opWordList_de">[Abgeordnetenhaus]</option>
+                      <option class="opWordList_de">[Abgeordnetenkammer]</option>
+                      <option class="opWordList_de">[Abgeordneter]</option>
+                      <option class="opWordList_de">[Abgeschiedenheit]</option>
+                      <option class="opWordList_de">[Abitur]</option>
+                      <option class="opWordList_de">[Abkürzung]</option>
+                      <option class="opWordList_de">[Ablenkung]</option>
+                      <option class="opWordList_de">[Ablflussrinne]</option>
+                      <option class="opWordList_de">[Ablutionskännchen]</option>
+                      <option class="opWordList_de">[Abmachung]</option>
+                      <option class="opWordList_de">[Abort]</option>
+                      <option class="opWordList_de">[Abortgrube]</option>
+                      <option class="opWordList_de">[Absatz]</option>
+                      <option class="opWordList_de">[Abscheu]</option>
+                      <option class="opWordList_de">[Abscheulichkeit]</option>
+                      <option class="opWordList_de">[Abschiedsgruß]</option>
+                      <option class="opWordList_de">[Abschneiden]</option>
+                      <option class="opWordList_de">[Abschnitt]</option>
+                      <option class="opWordList_de">[Absender]</option>
+                      <option class="opWordList_de">[Absicht]</option>
+                      <option class="opWordList_de">[Abstand]</option>
+                      <option class="opWordList_de">[Abstellbrett]</option>
+                      <option class="opWordList_de">[Abstellraum]</option>
+                      <option class="opWordList_de">[Abstieg]</option>
+                      <option class="opWordList_de">[Abszess]</option>
+                      <option class="opWordList_de">[Abteilungsleiter]</option>
+                      <option class="opWordList_de">[Abtritt]</option>
+                      <option class="opWordList_de">[Abwesenheit]</option>
+                      <option class="opWordList_de">[Abwickeln]</option>
+                      <option class="opWordList_de">[Abzweigung]</option>
+                      <option class="opWordList_de">[abbiegen]</option>
+                      <option class="opWordList_de">[abbrechen]</option>
+                      <option class="opWordList_de">[abdecken]</option>
+                      <option class="opWordList_de">[abendlich]</option>
+                      <option class="opWordList_de">[abendländisch]</option>
+                      <option class="opWordList_de">[aber]</option>
+                      <option class="opWordList_de">[abfahren]</option>
+                      <option class="opWordList_de">[abfangen]</option>
+                      <option class="opWordList_de">[abgeben]</option>
+                      <option class="opWordList_de">[abgebildet]</option>
+                      <option class="opWordList_de">[abgenutzt]</option>
+                      <option class="opWordList_de">[abgeschrieben]</option>
+                      <option class="opWordList_de">[abgeschält]</option>
+                      <option class="opWordList_de">[abgestempelt]</option>
+                      <option class="opWordList_de">[abgewirtschaftet]</option>
+                      <option class="opWordList_de">[abhauen]</option>
+                      <option class="opWordList_de">[abheben]</option>
+                      <option class="opWordList_de">[abhäuten]</option>
+                      <option class="opWordList_de">[ablehnen]</option>
+                      <option class="opWordList_de">[abliefern]</option>
+                      <option class="opWordList_de">[abmagern]</option>
+                      <option class="opWordList_de">[abnehmen]</option>
+                      <option class="opWordList_de">[abnormal]</option>
+                      <option class="opWordList_de">[abreisen]</option>
+                      <option class="opWordList_de">[abreißen]</option>
+                      <option class="opWordList_de">[abschaben]</option>
+                      <option class="opWordList_de">[abscheulich]</option>
+                      <option class="opWordList_de">[abschlachten]</option>
+                      <option class="opWordList_de">[abschneiden]</option>
+                      <option class="opWordList_de">[abschreiben]</option>
+                      <option class="opWordList_de">[abseihen]</option>
+                      <option class="opWordList_de">[absengen]</option>
+                      <option class="opWordList_de">[absichtlich]</option>
+                      <option class="opWordList_de">[absteigen]</option>
+                      <option class="opWordList_de">[abstoßen]</option>
+                      <option class="opWordList_de">[abstreiten]</option>
+                      <option class="opWordList_de">[abwaschen]</option>
+                      <option class="opWordList_de">[abwesend]</option>
+                      <option class="opWordList_de">[abwischen]</option>
+                      <option class="opWordList_de">[abziehen]</option>
+                      <option class="opWordList_en">[abdomen]</option>
+                      <option class="opWordList_en">[abhorrence]</option>
+                      <option class="opWordList_en">[ability]</option>
+                      <option class="opWordList_en">[ablution]</option>
+                      <option class="opWordList_en">[about]</option>
+                      <option class="opWordList_en">[above]</option>
+                      <option class="opWordList_en">[abroad]</option>
+                      <option class="opWordList_en">[abscess]</option>
+                      <option class="opWordList_en">[absence]</option>
+                      <option class="opWordList_en">[absent]</option>
+                      <option class="opWordList_en">[absolutely]</option>
+                      <option class="opWordList_en">[abundantly]</option>
+                      <option class="opWordList_fr">[abaissement]</option>
+                      <option class="opWordList_fr">[abaisser]</option>
+                      <option class="opWordList_fr">[abattage]</option>
+                      <option class="opWordList_fr">[abattement]</option>
+                      <option class="opWordList_fr">[abattre]</option>
+                      <option class="opWordList_fr">[abattu]</option>
+                      <option class="opWordList_fr">[abdomen]</option>
+                      <option class="opWordList_fr">[abeilles]</option>
+                      <option class="opWordList_fr">[ablution]</option>
+                      <option class="opWordList_fr">[aboiement]</option>
+                      <option class="opWordList_fr">[abonder]</option>
+                      <option class="opWordList_fr">[aboyer]</option>
+                      <option class="opWordList_fr">[abreuver]</option>
+                      <option class="opWordList_fr">[abricots]</option>
+                      <option class="opWordList_fr">[absence]</option>
+                      <option class="opWordList_fr">[absent]</option>
+                      <option class="opWordList_fr">[absolument]</option>
+                      <option class="opWordList_fr">[absolutment]</option>
+                      <option class="opWordList_fr">[abuser]</option>
+                      <option class="opWordList_fr">[abîmé]</option>
+                      <option class="opWordList_de">([Ab])hang</option>
+                      <option class="opWordList_de">([Ab])wiegen</option>
+                      <option class="opWordList_de">(Geld) [abheben]</option>
+                      <option class="opWordList_de">(Staub) [abklopfen]</option>
+                      <option class="opWordList_de">(Unter-)[Abteilung]</option>
+                      <option class="opWordList_de">(Zigarette) [abaschen]</option>
+                      <option class="opWordList_de">([ab])stützen</option>
+                      <option class="opWordList_de">([ab])wägen</option>
+                      <option class="opWordList_de">([ab]-)lecken</option>
+                      <option class="opWordList_de">(edle) [Abstammung]</option>
+                      <option class="opWordList_de">(früher) [Abend]</option>
+                      <option class="opWordList_de">(gute) [Absicht]</option>
+                      <option class="opWordList_de">(stark) [abnehmen]</option>
+                      <option class="opWordList_de">[Abscheu] erregen</option>
+                      <option class="opWordList_de">[Abschied] nehmen</option>
+                      <option class="opWordList_de">Guten [Abend]!</option>
+                      <option class="opWordList_de">Hau [ab]!</option>
+                      <option class="opWordList_de">Luft [ablassen]</option>
+                      <option class="opWordList_de">Stimme [abgeben]</option>
+                      <option class="opWordList_de">[abendliche] Feier</option>
+                      <option class="opWordList_de">[aber]...nicht</option>
+                      <option class="opWordList_de">[abgehen] (Zug)</option>
+                      <option class="opWordList_de">[abgenützt] werden</option>
+                      <option class="opWordList_de">[abgerissenes] Kleidungsstück</option>
+                      <option class="opWordList_de">[abgeschnittene] Locke</option>
+                      <option class="opWordList_de">[abgesehen] davon</option>
+                      <option class="opWordList_de">[abgesehen] von</option>
+                      <option class="opWordList_de">[abheben] (Geld)</option>
+                      <option class="opWordList_de">[abhängen] von</option>
+                      <option class="opWordList_de">[abhängig] von</option>
+                      <option class="opWordList_de">[abhören] (Patient)</option>
+                      <option class="opWordList_de">[ablassen] von</option>
+                      <option class="opWordList_de">[abschleppen] (Auto)</option>
+                      <option class="opWordList_de">[abspülen] (Geschirr)</option>
+                      <option class="opWordList_de">[abstürzen] (Computer</option>
+                      <option class="opWordList_de">[abtrünniger] Muslim</option>
+                      <option class="opWordList_de">[abwesend] sein</option>
+                      <option class="opWordList_de">[abzielen] auf</option>
+                      <option class="opWordList_de">en [abondance]</option>
+                      <option class="opWordList_de">etw. [abbrechen]</option>
+                      <option class="opWordList_de">etw. [abkratzen]</option>
+                      <option class="opWordList_de">gegen [Abend]</option>
+                      <option class="opWordList_de">heute [Abend]</option>
+                      <option class="opWordList_de">langsam [abfließen]</option>
+                      <option class="opWordList_de">mit [Absicht]</option>
+                      <option class="opWordList_de">nun [aber]</option>
+                      <option class="opWordList_de">sich [abmühen]</option>
+                      <option class="opWordList_de">vorgestern [Abend]</option>
+                      <option class="opWordList_en">[about] what</option>
+                      <option class="opWordList_en">[absolutely] nothing</option>
+                      <option class="opWordList_en">caring [about]</option>
+                      <option class="opWordList_en">from [above]</option>
+                      <option class="opWordList_en">from [abroad]</option>
+                      <option class="opWordList_en">to [abandon]</option>
+                      <option class="opWordList_en">to [abound]</option>
+                      <option class="opWordList_en">to [abuse]</option>
+                      <option class="opWordList_fr">[aborder] qc.</option>
+                      <option class="opWordList_fr">[abîmer] qc.</option>
+                      <option class="opWordList_fr">d'[abord]</option>
+                      <option class="opWordList_fr">devenir [abondant]</option>
+                      <option class="opWordList_fr">d’[abord]</option>
+                      <option class="opWordList_fr">règle [absolue]</option>
+                      <option class="opWordList_fr">s’[abîmer]</option>
+                      <option class="opWordList_fr">être [abandonné]</option>
+                      <option class="opWordList_fr">être [absent]</option>
+                      <option class="opWordList_de">([ab])wiegen (Gewicht)</option>
+                      <option class="opWordList_de">(die Schule/ das Studium) [abschließen]/[absolvieren]</option>
+                      <option class="opWordList_de">[Ablegen] von Gegenständen</option>
+                      <option class="opWordList_de">[Abreibung] (mit Seife)</option>
+                      <option class="opWordList_de">[Abweichung] (vom Rechten)</option>
+                      <option class="opWordList_de">[abgerissenes] zerlumptes Kleidungsstück</option>
+                      <option class="opWordList_de">[abgewickelt] werden (Geschäft)</option>
+                      <option class="opWordList_de">[abhängig] sein von</option>
+                      <option class="opWordList_de">[abnehmen] (den Telefonhörer)</option>
+                      <option class="opWordList_de">an jenem [Abend]</option>
+                      <option class="opWordList_de">austreten (auf [Abort])</option>
+                      <option class="opWordList_de">das Fell [abziehen]</option>
+                      <option class="opWordList_de">die [Absicht] habend...</option>
+                      <option class="opWordList_de">eine [Abteilung] Soldaten</option>
+                      <option class="opWordList_de">mit der [Absicht]</option>
+                      <option class="opWordList_de">sich (gegenseitig) [abküssen]</option>
+                      <option class="opWordList_de">sich [abwenden] von</option>
+                      <option class="opWordList_de">sich [abzeichnend] (Konturen)</option>
+                      <option class="opWordList_de">von ihm [abfallen]</option>
+                      <option class="opWordList_de">zu [Abend] essen</option>
+                      <option class="opWordList_de">zu [Abend] speisen</option>
+                      <option class="opWordList_en">hanging [about]/around</option>
+                      <option class="opWordList_en">to [abandon] sth.</option>
+                      <option class="opWordList_en">to [abate] (price)</option>
+                      <option class="opWordList_en">to be [abandoned]</option>
+                      <option class="opWordList_en">to be [able]</option>
+                      <option class="opWordList_en">to be [absent]</option>
+                      <option class="opWordList_en">to complain [about]</option>
+                      <option class="opWordList_en">to laze ([about])</option>
+                      <option class="opWordList_en">to reflect ([about])</option>
+                      <option class="opWordList_en">to strut [about]</option>
+                      <option class="opWordList_en">to think ([about])</option>
+                      <option class="opWordList_en">to worry [about]</option>
+                      <option class="opWordList_en">wandering [about]/around</option>
+                      <option class="opWordList_fr">[abandonner] qn./qc.</option>
+                      <option class="opWordList_fr">[abri] de fortune</option>
+                      <option class="opWordList_fr">ne... [absolument] personne</option>
+                      <option class="opWordList_fr">s'[abattre] sur</option>
+                      <option class="opWordList_fr">s’[absenter] (de)</option>
+                      <option class="opWordList_fr">tout d'[abord]</option>
+                      <option class="opWordList_de">[Absatz]/Stöckel der Schuhe</option>
+                      <option class="opWordList_de">[Abzug] (e-r Feuerwaffe)</option>
+                      <option class="opWordList_de">[Abzugsloch] unter der Feuerstelle</option>
+                      <option class="opWordList_de">[abgeschnittene] Locke der Braut</option>
+                      <option class="opWordList_de">[abgewinkelter] Eingangsbereich tunesischer Häuser</option>
+                      <option class="opWordList_de">[abschätziger] und verächtlicher Mann</option>
+                      <option class="opWordList_de">[abschüssige](r) Straße/ Weg</option>
+                      <option class="opWordList_de">des [Ablegens] von Kleidung</option>
+                      <option class="opWordList_de">die den Kachelfries [abschließt]</option>
+                      <option class="opWordList_de">eine große Schau [abziehen]</option>
+                      <option class="opWordList_de">j-m etw. [abknöpfen]</option>
+                      <option class="opWordList_de">j-m etw. [abluchsen]</option>
+                      <option class="opWordList_de">mit j-m [abrechnen]</option>
+                      <option class="opWordList_en">it is [absolutely] necessary</option>
+                      <option class="opWordList_en">to be passionate [about]</option>
+                      <option class="opWordList_en">to become [abundant]/plentiful</option>
+                      <option class="opWordList_en">to hang [about]/around</option>
+                      <option class="opWordList_en">to philosophize [about] sth.</option>
+                      <option class="opWordList_en">to wander [about]/around</option>
+                      <option class="opWordList_fr">avoir l'esprit [absent]</option>
+                      <option class="opWordList_fr">chevelure [abondante] et indisciplinée</option>
+                      <option class="opWordList_fr">il est [absolument] necessaire</option>
+                      <option class="opWordList_de">Schuheisen (für Spitze und [Absatz])</option>
+                      <option class="opWordList_de">Unterleder von Sohle und [Absatz]</option>
+                      <option class="opWordList_de">Wasch- und Wasserstelle sowie [Abort]</option>
+                      <option class="opWordList_de">[aber] geduldete) Zuschauerin (bei Familienfeiern)</option>
+                      <option class="opWordList_de">[abmessen] (mit e-m Hohlmaß</option>
+                      <option class="opWordList_de">an den Festtagen Verwandtschaftsbesuche [absolviert])</option>
+                      <option class="opWordList_de">befreien (verstopften Gang/Kanal/[Abfluss]</option>
+                      <option class="opWordList_de">der die einheimischen Märkte [abmacht]</option>
+                      <option class="opWordList_de">die das Trauerjahr [abschließende] Zeremonie</option>
+                      <option class="opWordList_de">mittels e-s Schlosses [ab]-</option>
+                      <option class="opWordList_en">to acquire knowledge [about] sth.</option>
+                      <option class="opWordList_en">to gossip [about] sb./sth.</option>
+                      <option class="opWordList_en">to perform the ritual [ablution]</option>
+                      <option class="opWordList_en">to talk [about] sth./sb.</option>
+                      <option class="opWordList_de">Feier zur schriftlichen [Abfassung] eines Heiratsübereinkommens</option>
+                      <option class="opWordList_de">Student bzw. [Absolvent] der Zitouna-Hochschule</option>
+                      <option class="opWordList_de">bei einer Prüfung schummeln oder [abschreiben]</option>
+                      <option class="opWordList_de">den Kuskusdämpfer mittels der qfīla [abdichten]</option>
+                      <option class="opWordList_de">sich [absichern] (durch Rücklagen o. ä.)</option>
+                      <option class="opWordList_en">to doubt of/[about] sth./sb.</option>
+                      <option class="opWordList_fr">employer [abondamment] le mot pénis (zibb)</option>
+                      <option class="opWordList_de">die als [Abgrenzung] einer landwirtschaftlichen Fläche dienen</option>
+                      <option class="opWordList_de">die gerne [abends] ausgeht und gerne feiert</option>
+                      <option class="opWordList_de">eifersüchtig auf die [Abgeschlossenheit] seiner Frau Bedachter</option>
+                      <option class="opWordList_en">a unit of mass ([about] 5 g)</option>
+                      <option class="opWordList_en">to [abundantly] use the word penis (zibb)</option>
+                      <option class="opWordList_en">to say bad things [about] sb./sth.</option>
+                      <option class="opWordList_de">[aber] von Männern wie Frauen unter sich gebraucht)</option>
+                      <option class="opWordList_de">die Verbindung/den Kontakt zu j-m [abbrechen]</option>
+                      <option class="opWordList_de">bezüglich auf einen Studenten bzw. [Absolventen] der Zitouna-Hochschule</option>
+                      <option class="opWordList_de">das Fell von Schlachttieren (an Schädel und Läufen) [absengen]</option>
+                      <option class="opWordList_en">What do I/do you/does he etc. think ([about]...)?</option>
+                      <option class="opWordList_de">sehr feine und geschmeidige Pantoffel mit [abgerundeter] Spitze und aus Kamelleder</option>
+                      <option class="opWordList_de">und 9. Tag nach einem Todesfall der leidtragenden Familie [abstattete] (obsoleter Brauch)</option>
+                      </div>
+          '500':
+            description: bad input parameter
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+    /vicav/corpus: 
+      get:
+        tags:
+          - noauth
+        summary: Search corpus
+        operationId: searchCorpus
+        description: |
+          By passing a well formed noSKE query as 'query' parameter, you can retrieve serach results
+        parameters:
+          - in: query
+            name: query
+            description: query to perform against NoSKE
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: print
+            required: false
+            description: 'Whether to retrieve a full HTML file with printer-friendly formatting.'
+            schema:
+              type: string
+        responses:
+          '200':
+            description: the transformed html
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/CorpusSearch'
+                examples: 
+                  corpus_search_json:
+                    summary: 'Corpus search results'
+                    value: 
+                      {
+                        "query":"dār",
+                        "hits":[
+                          {
+                            "u":"URFA-077_a72",
+                            "doc":"URFA-077",
+                            "docHits": [
+                              "URFA-077_a72"
+                            ],
+                            "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-077_xTok_001078\"><div class=\"left\"><span class=\"w\" id=\"URFA-077_xTok_001071\">āni<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-077_xTok_001072\">nāyim<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-077_xTok_001073\">hēne<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-077_xTok_001074\">b<\/span><span class=\"w\" id=\"URFA-077_xTok_001076\">ad<\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">haḏiyye<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">nāyim<\/span><span xml:space=\"preserve\"> <\/span><\/div><\/div>"
+                          },
+                          {
+                            "u":"URFA-115_a4",
+                            "doc":"URFA-115",
+                            "docHits": ["URFA-115_a4"],
+                            "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-115_xTok_000096\"><div class=\"left\"><span class=\"w\" id=\"URFA-115_xTok_000087\">rəḥalaw<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-115_xTok_000089\">xall<\/span><span class=\"w\" id=\"URFA-115_xTok_000091\">ō<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-115_xTok_000092\">b<\/span><span class=\"w\" id=\"URFA-115_xTok_000094\">ad<\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">w<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">šālaw<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">eger<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">miṯil<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">al<\/span><\/div><\/div>"
+                          },
+                          {
+                            "u":"URFA-122_a13",
+                            "docHits": ["URFA-122_a13"],
+                            "doc":"URFA-122",
+                            "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-122_xTok_000738\"><div class=\"left\"><span class=\"w\" id=\"URFA-122_xTok_000730\">u<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-122_xTok_000731\">ˀal<\/span><span class=\"w\" id=\"URFA-122_xTok_000733\">bāb<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-122_xTok_000734\">b<\/span><span class=\"w\" id=\"URFA-122_xTok_000736\">ad<\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">imčallṭīn<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">al<\/span><span class=\"w\">qīrān<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">aṭ<\/span><span class=\"w\">ṭūg<\/span><span xml:space=\"preserve\"> <\/span><\/div><\/div>"
+                          },
+                          {
+                            "u":"URFA-125_a9",
+                            "doc":"URFA-125",
+                            "docHits": ["URFA-125_a9"],
+                            "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-125_xTok_000258\"><div class=\"left\"><span class=\"w\" id=\"URFA-125_xTok_000253\">hēn<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000254\">ṛāyiḥ<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000255\">āni<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000256\">ˀarīd<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000257\">agḏ̣ub<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">aš<\/span><span class=\"w\">šēx<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">w<\/span><span class=\"w\">arīd<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">āni<\/span><span xml:space=\"preserve\"> <\/span><\/div><\/div>"
+                          }
+                        ]
+                      }
+            
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: div
+                    wrapped: false
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: > 
+                      <?xml version="1.0" encoding="UTF-8"?>
+                      <div xmlns="http://www.w3.org/1999/xhtml" xmlns:acdh="http://acdh.oeaw.ac.at" xmlns:tei="http://www.tei-c.org/ns/1.0" class="corpus-search-results">
+                          <h2 xml:space="preserve">Search results for dār</h2>
+                          <div class="corpus-search-result" id="corpus-w-URFA-077_xTok_001078">
+                              <div class="left">
+                                  <span class="w" id="URFA-077_xTok_001071">āni</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-077_xTok_001072">nāyim</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-077_xTok_001073">hēne</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-077_xTok_001074">b</span>
+                                  <span class="w" id="URFA-077_xTok_001076">ad</span>
+                              </div>
+                              <div class="keyword">
+                                  <span class="w">dār</span>
+                                  <span xml:space="preserve"></span>
+                              </div>
+                              <div class="right">
+                                  <span class="w">haḏiyye</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w">nāyim</span>
+                                  <span xml:space="preserve"></span>
+                              </div>
+                          </div>
+                          <div class="corpus-search-result" id="corpus-w-URFA-115_xTok_000096">
+                              <div class="left">
+                                  <span class="w" id="URFA-115_xTok_000087">rəḥalaw</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-115_xTok_000089">xall</span>
+                                  <span class="w" id="URFA-115_xTok_000091">ō</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-115_xTok_000092">b</span>
+                                  <span class="w" id="URFA-115_xTok_000094">ad</span>
+                              </div>
+                              <div class="keyword">
+                                  <span class="w">dār</span>
+                                  <span xml:space="preserve"></span>
+                              </div>
+                              <div class="right">
+                                  <span class="w">w</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w">šālaw</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w">eger</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w">miṯil</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w">al</span>
+                              </div>
+                          </div>
+                          <div class="corpus-search-result" id="corpus-w-URFA-122_xTok_000738">
+                              <div class="left">
+                                  <span class="w" id="URFA-122_xTok_000730">u</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-122_xTok_000731">ˀal</span>
+                                  <span class="w" id="URFA-122_xTok_000733">bāb</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-122_xTok_000734">b</span>
+                                  <span class="w" id="URFA-122_xTok_000736">ad</span>
+                              </div>
+                              <div class="keyword">
+                                  <span class="w">dār</span>
+                                  <span xml:space="preserve"></span>
+                              </div>
+                              <div class="right">
+                                  <span class="w">imčallṭīn</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w">al</span>
+                                  <span class="w">qīrān</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w">aṭ</span>
+                                  <span class="w">ṭūg</span>
+                                  <span xml:space="preserve"></span>
+                              </div>
+                          </div>
+                          <div class="corpus-search-result" id="corpus-w-URFA-125_xTok_000258">
+                              <div class="left">
+                                  <span class="w" id="URFA-125_xTok_000253">hēn</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-125_xTok_000254">ṛāyiḥ</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-125_xTok_000255">āni</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-125_xTok_000256">ˀarīd</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w" id="URFA-125_xTok_000257">agḏ̣ub</span>
+                                  <span xml:space="preserve"></span>
+                              </div>
+                              <div class="keyword">
+                                  <span class="w">dār</span>
+                                  <span xml:space="preserve"></span>
+                              </div>
+                              <div class="right">
+                                  <span class="w">aš</span>
+                                  <span class="w">šēx</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w">w</span>
+                                  <span class="w">arīd</span>
+                                  <span xml:space="preserve"></span>
+                                  <span class="w">āni</span>
+                                  <span xml:space="preserve"></span>
+                              </div>
+                          </div>
+                      </div>
+          '500':
+            description: bad input parameter
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
+    /vicav/corpus_text: 
+      get:
+        tags:
+          - noauth
+        summary: Get rendered corpus text
+        operationId: getCorpusText
+        description: |
+          A pageable set of corpus utterances from the given text.
+        parameters:
+          - in: query
+            name: id
+            description: Corpus text ID
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: size
+            required: false
+            description: 'How many results to retrieve in one query. Defaults to 10.'
+            schema:
+              type: number
+              default: 10
+          - in: query
+            name: page
+            required: false
+            description: 'Page number to retrieve. Defaults to 1.'
+            schema:
+              type: number
+              default: 1
+          - in: query
+            name: hits
+            description: Comma-separated token IDs to highlight
+            required: false
+            schema:
+              type: string
+          - in: query
+            name: print
+            required: false
+            description: 'Whether to retrieve a full HTML file with printer-friendly formatting.'
+            schema:
+              type: string
+        responses:
+          '200':
+            description: the transformed html
+            content:
+              application/json:
+                schema: 
+                  $ref: '#/components/schemas/CorpusText'
+                examples: 
+                  corpustext_json:
+                    summary: sample json response
+                    value:
+                      {
+                        "id": "$URFA-011",
+                        "utterances": [
+                          {
+                            "id": "URFA-011_a1",
+                            "content": "<div class=\"u\" id=\"URFA-011_a1\" />"
+                          },
+                          {
+                            "id": "URFA-011_a2",
+                            "content": "<div class=\"u\" id=\"URFA-011_a2\"><span class=\"w\" id=\"URFA-011_xTok_000001\">hāḏa</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000002\">l</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000004\">ᵊgbūr</span><span class=\"pc\" id=\"xTok_000005\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000006\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000008\">miǧanne</span><span class=\"pc\" id=\"xTok_000009\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000010\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000012\">gabǝr</span><span class=\"pc\" id=\"xTok_000013\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000014\">wāḥad</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000015\">ymūt</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000016\">yidfunūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000018\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000019\">hēne</span><span class=\"pc\" id=\"xTok_000020\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000021\">yidfunūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000023\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000024\">yqasslūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000026\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000027\">ʕala</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000028\">ʕurf</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000029\">islām</span><span class=\"pc\" id=\"xTok_000030\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000031\">ʕala</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000032\">ʕādāt</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000033\">uṣūl</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000034\">Islām</span><span class=\"pc\" id=\"xTok_000035\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000036\">yqassl</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000038\">u</span><span class=\"pc\" id=\"xTok_000039\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000040\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000042\">xōǧe</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000043\">yqassl</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000045\">u</span><span class=\"pc\" id=\"xTok_000046\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000047\">w</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000049\">yǧībūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000051\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000052\">hēne</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000053\">yčaffnūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000055\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000056\">yḥuṭṭūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000058\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000059\">b</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000061\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000063\">kefen</span><span class=\"pc\" id=\"xTok_000064\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000065\">čafan</span><span class=\"pc\" id=\"xTok_000066\">–</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000067\">kefen</span><span class=\"pc\" id=\"xTok_000068\">–</span><span class=\"w\" id=\"URFA-011_xTok_000069\">čafan</span><span class=\"pc\" id=\"xTok_000070\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000071\">ydummūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000073\">u</span><span class=\"pc\" id=\"xTok_000074\">.</span><span xml:space=\"preserve\"> </span></div>"
+                          },
+                          {
+                            "id": "URFA-011_a3",
+                            "content": "<div class=\"u\" id=\"URFA-011_a3\"><span class=\"w\" id=\"URFA-011_xTok_000075\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000077\">gabǝr</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000078\">baʕdēn</span><span class=\"pc\" id=\"xTok_000079\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000080\">ʕugub</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000081\">sabʕ</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000082\">ᵊsnīn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000083\">yigdarūn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000084\">yḥuṭṭūn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000085\">qēr</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000086\">wāḥad</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000087\">bī</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000089\">´</span><span class=\"pc\" id=\"xTok_000090\">.</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000091\">in</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000092\">mā</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000093\">ṣār</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000094\">sabʕ</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000095\">ᵊsnīn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000096\">qēr</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000097\">wāḥad</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000098\">mā</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000099\">yḥuṭṭūn</span><span class=\"pc\" id=\"xTok_000100\">.</span><span xml:space=\"preserve\"> </span></div>"
+                          }
+                        ]
+                      }
+              application/xml:
+                schema:
+                  type: string
+                  xml:
+                    name: div
+                    wrapped: false
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: > 
+                      <?xml version="1.0" encoding="UTF-8"?>
+                      <div xmlns="http://www.w3.org/1999/xhtml" xmlns:acdh="http://acdh.oeaw.ac.at" xmlns:tei="http://www.tei-c.org/ns/1.0" class="corpus-utterances">
+                          <div class="u" id="URFA-011_a3">
+                              <span class="w" id="URFA-011_xTok_000075">al</span>
+                              <span class="w" id="URFA-011_xTok_000077">gabǝr</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000078">baʕdēn</span>
+                              <span class="pc" id="xTok_000079">,</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000080">ʕugub</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000081">sabʕ</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000082">ᵊsnīn</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000083">yigdarūn</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000084">yḥuṭṭūn</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000085">qēr</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000086">wāḥad</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000087">bī</span>
+                              <span class="w" id="URFA-011_xTok_000089">´</span>
+                              <span class="pc" id="xTok_000090">.</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000091">in</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000092">mā</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000093">ṣār</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000094">sabʕ</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000095">ᵊsnīn</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000096">qēr</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000097">wāḥad</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000098">mā</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000099">yḥuṭṭūn</span>
+                              <span class="pc" id="xTok_000100">.</span>
+                              <span xml:space="preserve"></span>
+                          </div>
+                          <div class="u" id="URFA-011_a4">
+                              <span class="w" id="URFA-011_xTok_000101">ta</span>
+                              <span class="w" id="URFA-011_xTok_000103">ngūl</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000104">hāḏa</span>
+                              <span class="pc" id="xTok_000105">,</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000106">mayyit</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000107">luwwa</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000108">sine</span>
+                              <span class="pc" id="xTok_000109">,</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000110">al</span>
+                              <span class="w" id="URFA-011_xTok_000112">gabǝr</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000113">hāḏa</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000114">mā</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000115">yiftaḥūn</span>
+                              <span class="w" id="URFA-011_xTok_000117">u</span>
+                              <span class="pc" id="xTok_000118">–</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000119">mā</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000120">yiftaḥūn</span>
+                              <span class="w" id="URFA-011_xTok_000122">u</span>
+                              <span class="pc" id="xTok_000123">–</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000124">baˁad</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000125">sabˁ</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000126">ᵊsnīn</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000127">yiftaḥūn</span>
+                              <span class="w" id="URFA-011_xTok_000129">u</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000130">yigdarūn</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000131">in</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000132">māt</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000133">ḥade</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000134">in</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000135">ṣār</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000136">mayyit</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000137">uxṛa</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000138">l</span>
+                              <span class="w" id="URFA-011_xTok_000140">al</span>
+                              <span class="w" id="URFA-011_xTok_000142">ˁēle</span>
+                              <span class="pc" id="xTok_000143">,</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000144">kull</span>
+                              <span class="w" id="URFA-011_xTok_000146">min</span>
+                              <span class="pc" id="xTok_000147">…</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000148">ta</span>
+                              <span class="w" id="URFA-011_xTok_000150">ngūl</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000151">alḥaz</span>
+                              <span xml:space="preserve"></span>
+                              <span class="w" id="URFA-011_xTok_000152">iḥna</span>
+                              <span xml:space="preserve"></span>
+                          </div>
+                      </div>
+          '500':
+            description: bad input parameter
+            content:
+              application/xml:
+                schema:
+                  type: string
+                examples:
+                  html:
+                    summary: A sample HTML response
+                    value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
   components:
-
-  \  schemas:
-
-  \    CorpusText:\ 
-
-  \      type: object
-
-  \      properties:\ 
-
-  \        id:\ 
-
-  \          type: string
-
-  \        utterances:
-
-  \          type: array
-
-  \          items:\ 
-
-  \            $ref: '#/components/schemas/corpusText_utterances'
-
-  \    corpusText_utterances:
-
-  \      type: object
-
-  \      properties:\ 
-
-  \        id:\ 
-
-  \          type: string
-
-  \        content:\ 
-
-  \          type: string
-
-  \    CorpusSearch:
-
-  \      type: object
-
-  \      properties:\ 
-
-  \        query:\ 
-
-  \          type: string
-
-  \        hits:\ 
-
-  \          type: array
-
-  \          items:         \ 
-
-  \            $ref: '#/components/schemas/corpusSearch_hits'
-
-  \    corpusSearch_hits:\ 
-
-  \      type: object
-
-  \      properties:
-
-  \        u:\ 
-
-  \          type: string
-
-  \        docHits:\ 
-
-  \          type: array
-
-  \          items:\ 
-
-  \            type: string
-
-  \        doc:
-
-  \          type: string
-
-  \        content:\ 
-
-  \          type: string
-
-  \    ProjectConfig:
-
-  \      type: object
-
-  \      properties:
-
-  \        projectConfig:
-
-  \          $ref: '#/components/schemas/projectConfig_type'
-
-  \    projectConfig_type:
-
-  \      type: object
-
-  \      properties:
-
-  \        title:
-
-  \          type: string
-
-  \        logo:
-
-  \          $ref: '#/components/schemas/logo_type'
-
-  \        param:
-
-  \          $ref: '#/components/schemas/param_type'
-
-  \        panel:
-
-  \          $ref: '#/components/schemas/panel_type'
-
-  \        menu:
-
-  \          $ref: '#/components/schemas/menu_type'         \ 
-
-  \    logo_type:
-
-  \      type: object
-
-  \      properties:
-
-  \        img:
-
-  \          type: string
-
-  \    param_type:
-
-  \      type: array
-
-  \      minItems: 0
-
-  \      items:
-
-  \        type: string
-
-  \    panel_type:
-
-  \      type: array
-
-  \      minItems: 0
-
-  \      items:
-
-  \        type: object
-
-  \        properties:
-
-  \          type:
-
-  \            type: string
-
-  \          target:
-
-  \            type: string
-
-  \          title:
-
-  \            type: string
-
-  \        required:
-
-  \        - type
-
-  \        - title
-
-  \        - target
-
-  \    item_type:
-
-  \      type: array
-
-  \      minItems: 0
-
-  \      items:
-
-  \        type: object
-
-  \        properties:
-
-  \          id:
-
-  \            type: string
-
-  \          title:
-
-  \            type: string
-
-  \          type:
-
-  \            type: string
-
-  \            enum:
-
-  \            - item
-
-  \            - separator
-
-  \          componentName:
-
-  \            type: string
-
-  \            enum:
-
-  \            - WMap
-
-  \            - DictQuery
-
-  \            - CrossDictQuery
-
-  \            - BiblioQuery
-
-  \            - Text
-
-  \            - SampleText
-
-  \            - DataList
-
-  \            - CorpusQuery
-
-  \        required:
-
-  \        - type
-
-  \    main_type:
-
-  \      type: array
-
-  \      minItems: 0
-
-  \      items:
-
-  \        type: object
-
-  \        properties:
-
-  \          id:
-
-  \            type: string
-
-  \          title:
-
-  \            type: string
-
-  \          item:
-
-  \            $ref: '#/components/schemas/item_type'
-
-  \          type:
-
-  \            type: string
-
-  \            enum:
-
-  \            - dropdown
-
-  \        required:
-
-  \        - item
-
-  \        - id
-
-  \        - title
-
-  \        - type
-
-  \    subnav_type:
-
-  \      type: array
-
-  \      minItems: 0
-
-  \      items:
-
-  \        type: object
-
-  \        properties:
-
-  \          id:
-
-  \            type: string
-
-  \          class:
-
-  \            type: string
-
-  \          title:
-
-  \            type: string
-
-  \          type:
-
-  \            type: string
-
-  \        required:
-
-  \        - id
-
-  \        - title
-
-  \        - type
-
-  \    menu_type:
-
-  \      type: object
-
-  \      properties:
-
-  \        main:
-
-  \          $ref: '#/components/schemas/main_type'
-
-  \        subnav:
-
-  \          $ref: '#/components/schemas/subnav_type'
-
-  \    Feature:
-
-  \      title: GeoJSON Feature
-
-  \      type: object
-
-  \      required:
-
-  \      - type
-
-  \      - properties
-
-  \      - geometry
-
-  \      properties:
-
-  \        type:
-
-  \          type: string
-
-  \          enum:
-
-  \          - Feature
-
-  \        id:
-
-  \          oneOf:
-
-  \          - type: number
-
-  \          - type: string
-
-  \        properties:
-
-  \          oneOf:
-
-  \          - type: 'null'
-
-  \          - type: object
-
-  \        geometry:
-
-  \          oneOf:
-
-  \          - type: 'null'
-
-  \          - $ref: '#/components/schemas/Point'   \ 
-
-  \    Point:
-
-  \      title: GeoJSON Point
-
-  \      type: object
-
-  \      required:
-
-  \      - type
-
-  \      - coordinates
-
-  \      properties:
-
-  \        type:
-
-  \          type: string
-
-  \          enum:
-
-  \          - Point
-
-  \        coordinates:
-
-  \          type: array
-
-  \          minItems: 2
-
-  \          items:
-
-  \            type: number
-
-  \        bbox:
-
-  \          type: array
-
-  \          minItems: 4
-
-  \          items:
-
-  \            type: number
-
-  \           \ 
-
-  \           "
+    schemas:
+      CorpusText: 
+        type: object
+        properties: 
+          id: 
+            type: string
+          utterances:
+            type: array
+            items: 
+              $ref: '#/components/schemas/corpusText_utterances'
+      corpusText_utterances:
+        type: object
+        properties: 
+          id: 
+            type: string
+          content: 
+            type: string
+      CorpusSearch:
+        type: object
+        properties: 
+          query: 
+            type: string
+          hits: 
+            type: array
+            items:          
+              $ref: '#/components/schemas/corpusSearch_hits'
+      corpusSearch_hits: 
+        type: object
+        properties:
+          u: 
+            type: string
+          docHits: 
+            type: array
+            items: 
+              type: string
+          doc:
+            type: string
+          content: 
+            type: string
+      ProjectConfig:
+        type: object
+        properties:
+          projectConfig:
+            $ref: '#/components/schemas/projectConfig_type'
+      projectConfig_type:
+        type: object
+        properties:
+          title:
+            type: string
+          logo:
+            $ref: '#/components/schemas/logo_type'
+          param:
+            $ref: '#/components/schemas/param_type'
+          panel:
+            $ref: '#/components/schemas/panel_type'
+          menu:
+            $ref: '#/components/schemas/menu_type'          
+      logo_type:
+        type: object
+        properties:
+          img:
+            type: string
+      param_type:
+        type: array
+        minItems: 0
+        items:
+          type: string
+      panel_type:
+        type: array
+        minItems: 0
+        items:
+          type: object
+          properties:
+            type:
+              type: string
+            target:
+              type: string
+            title:
+              type: string
+          required:
+          - type
+          - title
+          - target
+      item_type:
+        type: array
+        minItems: 0
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+            title:
+              type: string
+            type:
+              type: string
+              enum:
+              - item
+              - separator
+            componentName:
+              type: string
+              enum:
+              - WMap
+              - DictQuery
+              - CrossDictQuery
+              - BiblioQuery
+              - Text
+              - SampleText
+              - DataList
+              - CorpusQuery
+          required:
+          - type
+      main_type:
+        type: array
+        minItems: 0
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+            title:
+              type: string
+            item:
+              $ref: '#/components/schemas/item_type'
+            type:
+              type: string
+              enum:
+              - dropdown
+          required:
+          - item
+          - id
+          - title
+          - type
+      subnav_type:
+        type: array
+        minItems: 0
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+            class:
+              type: string
+            title:
+              type: string
+            type:
+              type: string
+          required:
+          - id
+          - title
+          - type
+      menu_type:
+        type: object
+        properties:
+          main:
+            $ref: '#/components/schemas/main_type'
+          subnav:
+            $ref: '#/components/schemas/subnav_type'
+      Feature:
+        title: GeoJSON Feature
+        type: object
+        required:
+        - type
+        - properties
+        - geometry
+        properties:
+          type:
+            type: string
+            enum:
+            - Feature
+          id:
+            oneOf:
+            - type: number
+            - type: string
+          properties:
+            oneOf:
+            - type: 'null'
+            - type: object
+          geometry:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/Point'    
+      Point:
+        title: GeoJSON Point
+        type: object
+        required:
+        - type
+        - coordinates
+        properties:
+          type:
+            type: string
+            enum:
+            - Point
+          coordinates:
+            type: array
+            minItems: 2
+            items:
+              type: number
+          bbox:
+            type: array
+            minItems: 4
+            items:
+              type: number
 contentType: yaml

--- a/.insomnia/Request/req_wrk_6915256f54c24d51aa934588fd7b49ff1354378b.yml
+++ b/.insomnia/Request/req_wrk_6915256f54c24d51aa934588fd7b49ff1354378b.yml
@@ -1,7 +1,7 @@
 _id: req_wrk_6915256f54c24d51aa934588fd7b49ff1354378b
 type: Request
 parentId: fld_wrk_6915256f54c24d51aa934588fd7b49fffdee0559
-modified: 1675795155932
+modified: 1683292547257
 created: 1675795155932
 url: "{{ base_url }}/bibl_markers_tei"
 name: gets a geo marker information
@@ -11,13 +11,18 @@ body: {}
 parameters:
   - name: query
     disabled: false
-    value: Mörth
+    value: Ma.*
     id: pair_906fe1fd4259438dadc03af7d15e7276
   - name: scope
     disabled: false
     value: geo_reg
     id: pair_b5d1b93f15604eaf978bb4fd3f3e7000
-headers: []
+headers:
+  - id: pair_4e3ff315aaf84ed99e822fd82a8b6053
+    name: Accept
+    value: application/json
+    description: ""
+    disabled: false
 authentication: {}
 metaSortKey: -1675795155932
 isPrivate: false

--- a/openapi.json
+++ b/openapi.json
@@ -1179,6 +1179,41 @@
           "200": {
             "description": "the transformed html",
             "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CorpusSearch"
+                },
+                "examples": {
+                  "corpus_search_json": {
+                    "summary": "Corpus serach results",
+                    "value": {
+                      "query": "dār",
+                      "hits": [
+                        {
+                          "u": "URFA-077_a72",
+                          "doc": "URFA-077",
+                          "content": "<div class=\"corpus-search-result\" id=\"corpus-w-URFA-077_xTok_001078\"><div class=\"left\"><span class=\"w\" id=\"URFA-077_xTok_001071\">āni</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-077_xTok_001072\">nāyim</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-077_xTok_001073\">hēne</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-077_xTok_001074\">b</span><span class=\"w\" id=\"URFA-077_xTok_001076\">ad</span></div><div class=\"keyword\"><span class=\"w\">dār</span><span xml:space=\"preserve\"> </span></div><div class=\"right\"><span class=\"w\">haḏiyye</span><span xml:space=\"preserve\"> </span><span class=\"w\">nāyim</span><span xml:space=\"preserve\"> </span></div></div>"
+                        },
+                        {
+                          "u": "URFA-115_a4",
+                          "doc": "URFA-115",
+                          "content": "<div class=\"corpus-search-result\" id=\"corpus-w-URFA-115_xTok_000096\"><div class=\"left\"><span class=\"w\" id=\"URFA-115_xTok_000087\">rəḥalaw</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-115_xTok_000089\">xall</span><span class=\"w\" id=\"URFA-115_xTok_000091\">ō</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-115_xTok_000092\">b</span><span class=\"w\" id=\"URFA-115_xTok_000094\">ad</span></div><div class=\"keyword\"><span class=\"w\">dār</span><span xml:space=\"preserve\"> </span></div><div class=\"right\"><span class=\"w\">w</span><span xml:space=\"preserve\"> </span><span class=\"w\">šālaw</span><span xml:space=\"preserve\"> </span><span class=\"w\">eger</span><span xml:space=\"preserve\"> </span><span class=\"w\">miṯil</span><span xml:space=\"preserve\"> </span><span class=\"w\">al</span></div></div>"
+                        },
+                        {
+                          "u": "URFA-122_a13",
+                          "doc": "URFA-122",
+                          "content": "<div class=\"corpus-search-result\" id=\"corpus-w-URFA-122_xTok_000738\"><div class=\"left\"><span class=\"w\" id=\"URFA-122_xTok_000730\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-122_xTok_000731\">ˀal</span><span class=\"w\" id=\"URFA-122_xTok_000733\">bāb</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-122_xTok_000734\">b</span><span class=\"w\" id=\"URFA-122_xTok_000736\">ad</span></div><div class=\"keyword\"><span class=\"w\">dār</span><span xml:space=\"preserve\"> </span></div><div class=\"right\"><span class=\"w\">imčallṭīn</span><span xml:space=\"preserve\"> </span><span class=\"w\">al</span><span class=\"w\">qīrān</span><span xml:space=\"preserve\"> </span><span class=\"w\">aṭ</span><span class=\"w\">ṭūg</span><span xml:space=\"preserve\"> </span></div></div>"
+                        },
+                        {
+                          "u": "URFA-125_a9",
+                          "doc": "URFA-125",
+                          "content": "<div class=\"corpus-search-result\" id=\"corpus-w-URFA-125_xTok_000258\"><div class=\"left\"><span class=\"w\" id=\"URFA-125_xTok_000253\">hēn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-125_xTok_000254\">ṛāyiḥ</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-125_xTok_000255\">āni</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-125_xTok_000256\">ˀarīd</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-125_xTok_000257\">agḏ̣ub</span><span xml:space=\"preserve\"> </span></div><div class=\"keyword\"><span class=\"w\">dār</span><span xml:space=\"preserve\"> </span></div><div class=\"right\"><span class=\"w\">aš</span><span class=\"w\">šēx</span><span xml:space=\"preserve\"> </span><span class=\"w\">w</span><span class=\"w\">arīd</span><span xml:space=\"preserve\"> </span><span class=\"w\">āni</span><span xml:space=\"preserve\"> </span></div></div>"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
               "application/xml": {
                 "schema": {
                   "type": "string",
@@ -1267,6 +1302,33 @@
           "200": {
             "description": "the transformed html",
             "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CorpusText"
+                },
+                "examples": {
+                  "corpustext_json": {
+                    "summary": "sample json response",
+                    "value": {
+                      "id": "$URFA-011",
+                      "utterances": [
+                        {
+                          "id": "URFA-011_a1",
+                          "content": "<div class=\"u\" id=\"URFA-011_a1\" />"
+                        },
+                        {
+                          "id": "URFA-011_a2",
+                          "content": "<div class=\"u\" id=\"URFA-011_a2\"><span class=\"w\" id=\"URFA-011_xTok_000001\">hāḏa</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000002\">l</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000004\">ᵊgbūr</span><span class=\"pc\" id=\"xTok_000005\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000006\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000008\">miǧanne</span><span class=\"pc\" id=\"xTok_000009\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000010\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000012\">gabǝr</span><span class=\"pc\" id=\"xTok_000013\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000014\">wāḥad</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000015\">ymūt</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000016\">yidfunūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000018\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000019\">hēne</span><span class=\"pc\" id=\"xTok_000020\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000021\">yidfunūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000023\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000024\">yqasslūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000026\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000027\">ʕala</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000028\">ʕurf</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000029\">islām</span><span class=\"pc\" id=\"xTok_000030\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000031\">ʕala</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000032\">ʕādāt</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000033\">uṣūl</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000034\">Islām</span><span class=\"pc\" id=\"xTok_000035\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000036\">yqassl</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000038\">u</span><span class=\"pc\" id=\"xTok_000039\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000040\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000042\">xōǧe</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000043\">yqassl</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000045\">u</span><span class=\"pc\" id=\"xTok_000046\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000047\">w</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000049\">yǧībūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000051\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000052\">hēne</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000053\">yčaffnūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000055\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000056\">yḥuṭṭūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000058\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000059\">b</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000061\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000063\">kefen</span><span class=\"pc\" id=\"xTok_000064\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000065\">čafan</span><span class=\"pc\" id=\"xTok_000066\">–</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000067\">kefen</span><span class=\"pc\" id=\"xTok_000068\">–</span><span class=\"w\" id=\"URFA-011_xTok_000069\">čafan</span><span class=\"pc\" id=\"xTok_000070\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000071\">ydummūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000073\">u</span><span class=\"pc\" id=\"xTok_000074\">.</span><span xml:space=\"preserve\"> </span></div>"
+                        },
+                        {
+                          "id": "URFA-011_a3",
+                          "content": "<div class=\"u\" id=\"URFA-011_a3\"><span class=\"w\" id=\"URFA-011_xTok_000075\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000077\">gabǝr</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000078\">baʕdēn</span><span class=\"pc\" id=\"xTok_000079\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000080\">ʕugub</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000081\">sabʕ</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000082\">ᵊsnīn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000083\">yigdarūn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000084\">yḥuṭṭūn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000085\">qēr</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000086\">wāḥad</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000087\">bī</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000089\">´</span><span class=\"pc\" id=\"xTok_000090\">.</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000091\">in</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000092\">mā</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000093\">ṣār</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000094\">sabʕ</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000095\">ᵊsnīn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000096\">qēr</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000097\">wāḥad</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000098\">mā</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000099\">yḥuṭṭūn</span><span class=\"pc\" id=\"xTok_000100\">.</span><span xml:space=\"preserve\"> </span></div>"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
               "application/xml": {
                 "schema": {
                   "type": "string",
@@ -1306,6 +1368,59 @@
   },
   "components": {
     "schemas": {
+      "CorpusText": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "utterances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/corpusText_utterances"
+            }
+          }
+        }
+      },
+      "corpusText_utterances": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      },
+      "CorpusSearch": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "hits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/corpusSearch_hits"
+            }
+          }
+        }
+      },
+      "corpusSearch_hits": {
+        "type": "object",
+        "properties": {
+          "u": {
+            "type": "string"
+          },
+          "doc": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      },
       "ProjectConfig": {
         "type": "object",
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -1185,28 +1185,40 @@
                 },
                 "examples": {
                   "corpus_search_json": {
-                    "summary": "Corpus serach results",
+                    "summary": "Corpus search results",
                     "value": {
                       "query": "dār",
                       "hits": [
                         {
                           "u": "URFA-077_a72",
                           "doc": "URFA-077",
+                          "docHits": [
+                            "URFA-077_a72"
+                          ],
                           "content": "<div class=\"corpus-search-result\" id=\"corpus-w-URFA-077_xTok_001078\"><div class=\"left\"><span class=\"w\" id=\"URFA-077_xTok_001071\">āni</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-077_xTok_001072\">nāyim</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-077_xTok_001073\">hēne</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-077_xTok_001074\">b</span><span class=\"w\" id=\"URFA-077_xTok_001076\">ad</span></div><div class=\"keyword\"><span class=\"w\">dār</span><span xml:space=\"preserve\"> </span></div><div class=\"right\"><span class=\"w\">haḏiyye</span><span xml:space=\"preserve\"> </span><span class=\"w\">nāyim</span><span xml:space=\"preserve\"> </span></div></div>"
                         },
                         {
                           "u": "URFA-115_a4",
                           "doc": "URFA-115",
+                          "docHits": [
+                            "URFA-115_a4"
+                          ],
                           "content": "<div class=\"corpus-search-result\" id=\"corpus-w-URFA-115_xTok_000096\"><div class=\"left\"><span class=\"w\" id=\"URFA-115_xTok_000087\">rəḥalaw</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-115_xTok_000089\">xall</span><span class=\"w\" id=\"URFA-115_xTok_000091\">ō</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-115_xTok_000092\">b</span><span class=\"w\" id=\"URFA-115_xTok_000094\">ad</span></div><div class=\"keyword\"><span class=\"w\">dār</span><span xml:space=\"preserve\"> </span></div><div class=\"right\"><span class=\"w\">w</span><span xml:space=\"preserve\"> </span><span class=\"w\">šālaw</span><span xml:space=\"preserve\"> </span><span class=\"w\">eger</span><span xml:space=\"preserve\"> </span><span class=\"w\">miṯil</span><span xml:space=\"preserve\"> </span><span class=\"w\">al</span></div></div>"
                         },
                         {
                           "u": "URFA-122_a13",
+                          "docHits": [
+                            "URFA-122_a13"
+                          ],
                           "doc": "URFA-122",
                           "content": "<div class=\"corpus-search-result\" id=\"corpus-w-URFA-122_xTok_000738\"><div class=\"left\"><span class=\"w\" id=\"URFA-122_xTok_000730\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-122_xTok_000731\">ˀal</span><span class=\"w\" id=\"URFA-122_xTok_000733\">bāb</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-122_xTok_000734\">b</span><span class=\"w\" id=\"URFA-122_xTok_000736\">ad</span></div><div class=\"keyword\"><span class=\"w\">dār</span><span xml:space=\"preserve\"> </span></div><div class=\"right\"><span class=\"w\">imčallṭīn</span><span xml:space=\"preserve\"> </span><span class=\"w\">al</span><span class=\"w\">qīrān</span><span xml:space=\"preserve\"> </span><span class=\"w\">aṭ</span><span class=\"w\">ṭūg</span><span xml:space=\"preserve\"> </span></div></div>"
                         },
                         {
                           "u": "URFA-125_a9",
                           "doc": "URFA-125",
+                          "docHits": [
+                            "URFA-125_a9"
+                          ],
                           "content": "<div class=\"corpus-search-result\" id=\"corpus-w-URFA-125_xTok_000258\"><div class=\"left\"><span class=\"w\" id=\"URFA-125_xTok_000253\">hēn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-125_xTok_000254\">ṛāyiḥ</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-125_xTok_000255\">āni</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-125_xTok_000256\">ˀarīd</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-125_xTok_000257\">agḏ̣ub</span><span xml:space=\"preserve\"> </span></div><div class=\"keyword\"><span class=\"w\">dār</span><span xml:space=\"preserve\"> </span></div><div class=\"right\"><span class=\"w\">aš</span><span class=\"w\">šēx</span><span xml:space=\"preserve\"> </span><span class=\"w\">w</span><span class=\"w\">arīd</span><span xml:space=\"preserve\"> </span><span class=\"w\">āni</span><span xml:space=\"preserve\"> </span></div></div>"
                         }
                       ]
@@ -1286,6 +1298,15 @@
             "schema": {
               "type": "number",
               "default": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "hits",
+            "description": "Comma-separated token IDs to highlight",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           },
           {
@@ -1412,6 +1433,12 @@
         "properties": {
           "u": {
             "type": "string"
+          },
+          "docHits": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "doc": {
             "type": "string"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -831,7 +831,7 @@ paths:
       summary: gets a geo marker information 
       operationId: getMarkers
       description: |
-        By passing the appropriate xml-ID and xslt you can retrieve ready to display html
+        Retrieve geo data information from the bibliography for displaying coordinates on a map.
       parameters:
         - in: query
           name: query
@@ -871,7 +871,7 @@ paths:
             - diaGroup
       responses:
         '200':
-          description: an xml result list to the query
+          description: a list of geo markers
           content:
             application/xml:
               schema:
@@ -883,7 +883,7 @@ paths:
                   type: object
               examples:
                 xml:
-                  summary: A list of geo markers
+                  summary: a list of geo markers
                   value: >
                     <rs type="60">
                       <r type="geo">

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -873,6 +873,48 @@ paths:
         '200':
           description: a list of geo markers
           content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  schema:
+                    $ref: '#/components/schemas/Feature'
+              examples:
+                geoJSON_features_Ma_geo_reg:
+                  summary: 'query: Ma.*. scope: geo_reg, shorted'
+                  value: [
+                          {
+                            "type": "Feature",
+                            "geometry": {
+                              "type": "Point",
+                              "coordinates": [
+                                "35.578333",
+                                "-5.368056"
+                              ]
+                            },
+                            "properties": {
+                              "type": "geo",
+                              "name": "Tétouan",
+                              "hitCount": "16"
+                            }
+                          },
+                          {
+                            "type": "Feature",
+                            "geometry": {
+                              "type": "Point",
+                              "coordinates": [
+                                "32.000000",
+                                "-6.000000"
+                              ]
+                            },
+                            "properties": {
+                              "type": "reg",
+                              "name": "Morocco",
+                              "hitCount": "1157"
+                            }
+                          }
+                        ]
             application/xml:
               schema:
                 type: string
@@ -1491,3 +1533,48 @@ components:
           $ref: '#/components/schemas/main_type'
         subnav:
           $ref: '#/components/schemas/subnav_type'
+    Feature:
+      title: GeoJSON Feature
+      type: object
+      required:
+      - type
+      - properties
+      - geometry
+      properties:
+        type:
+          type: string
+          enum:
+          - Feature
+        id:
+          oneOf:
+          - type: number
+          - type: string
+        properties:
+          oneOf:
+          - type: 'null'
+          - type: object
+        geometry:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/Point'    
+    Point:
+      title: GeoJSON Point
+      type: object
+      required:
+      - type
+      - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+          - Point
+        coordinates:
+          type: array
+          minItems: 2
+          items:
+            type: number
+        bbox:
+          type: array
+          minItems: 4
+          items:
+            type: number

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1445,7 +1445,7 @@ paths:
                 $ref: '#/components/schemas/CorpusSearch'
               examples: 
                 corpus_search_json:
-                  summary: 'Corpus serach results'
+                  summary: 'Corpus search results'
                   value: 
                     {
                       "query":"dār",
@@ -1453,21 +1453,27 @@ paths:
                         {
                           "u":"URFA-077_a72",
                           "doc":"URFA-077",
+                          "docHits": [
+                            "URFA-077_a72"
+                          ],
                           "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-077_xTok_001078\"><div class=\"left\"><span class=\"w\" id=\"URFA-077_xTok_001071\">āni<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-077_xTok_001072\">nāyim<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-077_xTok_001073\">hēne<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-077_xTok_001074\">b<\/span><span class=\"w\" id=\"URFA-077_xTok_001076\">ad<\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">haḏiyye<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">nāyim<\/span><span xml:space=\"preserve\"> <\/span><\/div><\/div>"
                         },
                         {
                           "u":"URFA-115_a4",
                           "doc":"URFA-115",
+                          "docHits": ["URFA-115_a4"],
                           "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-115_xTok_000096\"><div class=\"left\"><span class=\"w\" id=\"URFA-115_xTok_000087\">rəḥalaw<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-115_xTok_000089\">xall<\/span><span class=\"w\" id=\"URFA-115_xTok_000091\">ō<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-115_xTok_000092\">b<\/span><span class=\"w\" id=\"URFA-115_xTok_000094\">ad<\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">w<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">šālaw<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">eger<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">miṯil<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">al<\/span><\/div><\/div>"
                         },
                         {
                           "u":"URFA-122_a13",
+                          "docHits": ["URFA-122_a13"],
                           "doc":"URFA-122",
                           "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-122_xTok_000738\"><div class=\"left\"><span class=\"w\" id=\"URFA-122_xTok_000730\">u<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-122_xTok_000731\">ˀal<\/span><span class=\"w\" id=\"URFA-122_xTok_000733\">bāb<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-122_xTok_000734\">b<\/span><span class=\"w\" id=\"URFA-122_xTok_000736\">ad<\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">imčallṭīn<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">al<\/span><span class=\"w\">qīrān<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">aṭ<\/span><span class=\"w\">ṭūg<\/span><span xml:space=\"preserve\"> <\/span><\/div><\/div>"
                         },
                         {
                           "u":"URFA-125_a9",
                           "doc":"URFA-125",
+                          "docHits": ["URFA-125_a9"],
                           "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-125_xTok_000258\"><div class=\"left\"><span class=\"w\" id=\"URFA-125_xTok_000253\">hēn<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000254\">ṛāyiḥ<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000255\">āni<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000256\">ˀarīd<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000257\">agḏ̣ub<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">aš<\/span><span class=\"w\">šēx<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">w<\/span><span class=\"w\">arīd<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">āni<\/span><span xml:space=\"preserve\"> <\/span><\/div><\/div>"
                         }
                       ]
@@ -1627,6 +1633,12 @@ paths:
           schema:
             type: number
             default: 1
+        - in: query
+          name: hits
+          description: Comma-separated token IDs to highlight
+          required: false
+          schema:
+            type: string
         - in: query
           name: print
           required: false
@@ -1834,6 +1846,10 @@ components:
       properties:
         u: 
           type: string
+        docHits: 
+          type: array
+          items: 
+            type: string
         doc:
           type: string
         content: 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1440,6 +1440,39 @@ paths:
         '200':
           description: the transformed html
           content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CorpusSearch'
+              examples: 
+                corpus_search_json:
+                  summary: 'Corpus serach results'
+                  value: 
+                    {
+                      "query":"dār",
+                      "hits":[
+                        {
+                          "u":"URFA-077_a72",
+                          "doc":"URFA-077",
+                          "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-077_xTok_001078\"><div class=\"left\"><span class=\"w\" id=\"URFA-077_xTok_001071\">āni<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-077_xTok_001072\">nāyim<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-077_xTok_001073\">hēne<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-077_xTok_001074\">b<\/span><span class=\"w\" id=\"URFA-077_xTok_001076\">ad<\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">haḏiyye<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">nāyim<\/span><span xml:space=\"preserve\"> <\/span><\/div><\/div>"
+                        },
+                        {
+                          "u":"URFA-115_a4",
+                          "doc":"URFA-115",
+                          "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-115_xTok_000096\"><div class=\"left\"><span class=\"w\" id=\"URFA-115_xTok_000087\">rəḥalaw<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-115_xTok_000089\">xall<\/span><span class=\"w\" id=\"URFA-115_xTok_000091\">ō<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-115_xTok_000092\">b<\/span><span class=\"w\" id=\"URFA-115_xTok_000094\">ad<\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">w<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">šālaw<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">eger<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">miṯil<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">al<\/span><\/div><\/div>"
+                        },
+                        {
+                          "u":"URFA-122_a13",
+                          "doc":"URFA-122",
+                          "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-122_xTok_000738\"><div class=\"left\"><span class=\"w\" id=\"URFA-122_xTok_000730\">u<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-122_xTok_000731\">ˀal<\/span><span class=\"w\" id=\"URFA-122_xTok_000733\">bāb<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-122_xTok_000734\">b<\/span><span class=\"w\" id=\"URFA-122_xTok_000736\">ad<\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">imčallṭīn<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">al<\/span><span class=\"w\">qīrān<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">aṭ<\/span><span class=\"w\">ṭūg<\/span><span xml:space=\"preserve\"> <\/span><\/div><\/div>"
+                        },
+                        {
+                          "u":"URFA-125_a9",
+                          "doc":"URFA-125",
+                          "content":"<div class=\"corpus-search-result\" id=\"corpus-w-URFA-125_xTok_000258\"><div class=\"left\"><span class=\"w\" id=\"URFA-125_xTok_000253\">hēn<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000254\">ṛāyiḥ<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000255\">āni<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000256\">ˀarīd<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\" id=\"URFA-125_xTok_000257\">agḏ̣ub<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"keyword\"><span class=\"w\">dār<\/span><span xml:space=\"preserve\"> <\/span><\/div><div class=\"right\"><span class=\"w\">aš<\/span><span class=\"w\">šēx<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">w<\/span><span class=\"w\">arīd<\/span><span xml:space=\"preserve\"> <\/span><span class=\"w\">āni<\/span><span xml:space=\"preserve\"> <\/span><\/div><\/div>"
+                        }
+                      ]
+                    }
+          
             application/xml:
               schema:
                 type: string
@@ -1604,6 +1637,30 @@ paths:
         '200':
           description: the transformed html
           content:
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/CorpusText'
+              examples: 
+                corpustext_json:
+                  summary: sample json response
+                  value:
+                    {
+                      "id": "$URFA-011",
+                      "utterances": [
+                        {
+                          "id": "URFA-011_a1",
+                          "content": "<div class=\"u\" id=\"URFA-011_a1\" />"
+                        },
+                        {
+                          "id": "URFA-011_a2",
+                          "content": "<div class=\"u\" id=\"URFA-011_a2\"><span class=\"w\" id=\"URFA-011_xTok_000001\">hāḏa</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000002\">l</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000004\">ᵊgbūr</span><span class=\"pc\" id=\"xTok_000005\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000006\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000008\">miǧanne</span><span class=\"pc\" id=\"xTok_000009\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000010\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000012\">gabǝr</span><span class=\"pc\" id=\"xTok_000013\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000014\">wāḥad</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000015\">ymūt</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000016\">yidfunūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000018\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000019\">hēne</span><span class=\"pc\" id=\"xTok_000020\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000021\">yidfunūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000023\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000024\">yqasslūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000026\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000027\">ʕala</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000028\">ʕurf</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000029\">islām</span><span class=\"pc\" id=\"xTok_000030\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000031\">ʕala</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000032\">ʕādāt</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000033\">uṣūl</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000034\">Islām</span><span class=\"pc\" id=\"xTok_000035\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000036\">yqassl</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000038\">u</span><span class=\"pc\" id=\"xTok_000039\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000040\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000042\">xōǧe</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000043\">yqassl</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000045\">u</span><span class=\"pc\" id=\"xTok_000046\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000047\">w</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000049\">yǧībūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000051\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000052\">hēne</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000053\">yčaffnūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000055\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000056\">yḥuṭṭūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000058\">u</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000059\">b</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000061\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000063\">kefen</span><span class=\"pc\" id=\"xTok_000064\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000065\">čafan</span><span class=\"pc\" id=\"xTok_000066\">–</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000067\">kefen</span><span class=\"pc\" id=\"xTok_000068\">–</span><span class=\"w\" id=\"URFA-011_xTok_000069\">čafan</span><span class=\"pc\" id=\"xTok_000070\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000071\">ydummūn</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000073\">u</span><span class=\"pc\" id=\"xTok_000074\">.</span><span xml:space=\"preserve\"> </span></div>"
+                        },
+                        {
+                          "id": "URFA-011_a3",
+                          "content": "<div class=\"u\" id=\"URFA-011_a3\"><span class=\"w\" id=\"URFA-011_xTok_000075\">al</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000077\">gabǝr</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000078\">baʕdēn</span><span class=\"pc\" id=\"xTok_000079\">,</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000080\">ʕugub</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000081\">sabʕ</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000082\">ᵊsnīn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000083\">yigdarūn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000084\">yḥuṭṭūn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000085\">qēr</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000086\">wāḥad</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000087\">bī</span><span>-</span><span class=\"w\" id=\"URFA-011_xTok_000089\">´</span><span class=\"pc\" id=\"xTok_000090\">.</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000091\">in</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000092\">mā</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000093\">ṣār</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000094\">sabʕ</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000095\">ᵊsnīn</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000096\">qēr</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000097\">wāḥad</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000098\">mā</span><span xml:space=\"preserve\"> </span><span class=\"w\" id=\"URFA-011_xTok_000099\">yḥuṭṭūn</span><span class=\"pc\" id=\"xTok_000100\">.</span><span xml:space=\"preserve\"> </span></div>"
+                        }
+                      ]
+                    }
             application/xml:
               schema:
                 type: string
@@ -1747,6 +1804,40 @@ paths:
                   value: '<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>'
 components:
   schemas:
+    CorpusText: 
+      type: object
+      properties: 
+        id: 
+          type: string
+        utterances:
+          type: array
+          items: 
+            $ref: '#/components/schemas/corpusText_utterances'
+    corpusText_utterances:
+      type: object
+      properties: 
+        id: 
+          type: string
+        content: 
+          type: string
+    CorpusSearch:
+      type: object
+      properties: 
+        query: 
+          type: string
+        hits: 
+          type: array
+          items:          
+            $ref: '#/components/schemas/corpusSearch_hits'
+    corpusSearch_hits: 
+      type: object
+      properties:
+        u: 
+          type: string
+        doc:
+          type: string
+        content: 
+          type: string
     ProjectConfig:
       type: object
       properties:


### PR DESCRIPTION
* A new 'docHits' key in result schema of /corpus (Corpus search) endpoint
* A new, optional 'hits' parameter for /corpus_text endpoint which adds a highlighting "hit" class to the provided token IDs in the text.