### PR TITLE
fix: make QueryDescription properties required

### DIFF
--- a/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
+++ b/.insomnia/ApiSpec/spc_8ea7cfbb1b844196a75f9766a024be57.yml
@@ -1,7 +1,7 @@
 _id: spc_8ea7cfbb1b844196a75f9766a024be57
 type: ApiSpec
 parentId: wrk_6915256f54c24d51aa934588fd7b49ff
-modified: 1695978428973
+modified: 1695982920846
 created: 1675182326019
 fileName: Current Vicav API 1.0.0
 contents: >
@@ -2804,6 +2804,10 @@ contents: >
         - type
       query_description:
         type: object
+        required:
+          - endpoint
+          - query
+          - scope
         properties:
           endpoint:
             type: string


### PR DESCRIPTION
this makes the properties on `QueryDescription` required (which i think they are).